### PR TITLE
Add biological replicate merging via --min-replicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Biological replicate merging via `--min-replicates N` and manifest `group` column
+- Auto-inference of replicate groups from sample IDs (strips `_repNN` suffix)
 - Subcommand architecture: `build`, `analyze`, `discover`, `dtu`
 - Variant-based genomic feature system (`exon_feature`, `segment_feature`)
 - Edge metadata and graph structure with segment-level edge deduplication
@@ -46,3 +48,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expression storage via lazy `expression_store` (null pointer for features without expression, flat vector with sentinel)
 - Removed stored coordinate strings from features (computed on demand from `genomic_coordinate`)
 - Removed unused `overlapping_features` field from `exon_feature`
+- `sorted_vec` replaces `unordered_set<uint32_t>` for `transcript_ids` on exons and segments (~13% memory reduction)

--- a/include/builder.hpp
+++ b/include/builder.hpp
@@ -52,7 +52,8 @@ public:
         const std::vector<sample_info>& samples,
         uint32_t threads = 1,
         float min_expression = -1.0f,
-        bool absorb = true
+        bool absorb = true,
+        int min_replicates = 0
     );
 
     /**
@@ -73,6 +74,15 @@ public:
     // Future extension methods for Phase 2/3:
     // static void add_discovered_transcripts(grove_type& grove, const std::vector<alignment_entry>& reads);
     // static void add_fusion_segments(grove_type& grove, const fusion_data& fusions);
+
+private:
+    /// Post-build merge of biological replicates within groups.
+    /// Iterates exon and segment caches (no grove traversal).
+    static void merge_replicates(
+        chromosome_exon_caches& exon_caches,
+        chromosome_segment_caches& segment_caches,
+        int min_replicates
+    );
 };
 
 #endif //ATROPLEX_GENOGROVE_BUILDER_HPP

--- a/include/genomic_feature.hpp
+++ b/include/genomic_feature.hpp
@@ -66,6 +66,13 @@ public:
         return (words_[wi] & bit_mask(id)) != 0;
     }
 
+    void clear(uint32_t id) {
+        size_t wi = word_index(id);
+        if (wi < words_.size()) {
+            words_[wi] &= ~bit_mask(id);
+        }
+    }
+
     size_t count() const {
         size_t n = 0;
         for (uint64_t w : words_) n += static_cast<size_t>(__builtin_popcountll(w));
@@ -208,6 +215,13 @@ public:
     }
 
     bool empty() const { return !data_; }
+
+    /// Remove expression for a specific sample (reset to sentinel)
+    void remove(uint32_t sid) {
+        if (data_ && sid < data_->size()) {
+            (*data_)[sid] = SENTINEL;
+        }
+    }
 
     /// Accumulate: add value to existing (or set if not present)
     void accumulate(uint32_t sid, float value) {

--- a/include/sample_info.hpp
+++ b/include/sample_info.hpp
@@ -82,7 +82,8 @@ struct sample_info {
 
     // Core identifiers
     std::string id;                     // Unique identifier
-    std::string type = "sample";        // Entry type: "sample" or "annotation"
+    std::string type = "sample";        // Entry type: "sample", "annotation", or "replicate" (merged)
+    std::string group;                  // Replicate group (e.g., ENCSR experiment ID); empty = no group
     std::string description;            // Free-text description
     std::filesystem::path source_file;  // Original input file path
 
@@ -126,6 +127,11 @@ struct sample_info {
         : id(std::move(sample_id)), source_file(std::move(file)) {}
 
     // Builder-style setters for fluent API
+    sample_info& with_group(std::string g) {
+        group = std::move(g);
+        return *this;
+    }
+
     sample_info& with_description(std::string d) {
         description = std::move(d);
         return *this;
@@ -246,6 +252,7 @@ struct sample_info {
         // Core
         write_string(id);
         write_string(type);
+        write_string(group);
         write_string(description);
         write_path(source_file);
 
@@ -302,6 +309,7 @@ struct sample_info {
         // Core
         info.id = read_string();
         info.type = read_string();
+        info.group = read_string();
         info.description = read_string();
         info.source_file = read_path();
 

--- a/src/index_stats.cpp
+++ b/src/index_stats.cpp
@@ -1296,12 +1296,26 @@ void index_stats::write_summary(const std::string& path) const {
     // Input entries
     if (!annotation_sources.empty()) {
         auto& reg = sample_registry::instance();
-        out << "Inputs: " << reg.size() << " entries (";
-        out << total_samples << " samples, "
-            << (reg.size() - total_samples) << " annotations)\n";
+
+        // Count entry types
+        size_t n_annotations = 0, n_replicates = 0;
         for (size_t i = 0; i < reg.size(); ++i) {
             const auto* info = reg.get(static_cast<uint32_t>(i));
-            if (info && !info->id.empty()) {
+            if (!info) continue;
+            if (info->type == "annotation") n_annotations++;
+            else if (info->type == "replicate") n_replicates++;
+        }
+
+        out << "Inputs: " << (reg.size() - n_replicates) << " entries ("
+            << total_samples << " samples, "
+            << n_annotations << " annotations";
+        if (n_replicates > 0) {
+            out << ", " << n_replicates << " replicates merged";
+        }
+        out << ")\n";
+        for (size_t i = 0; i < reg.size(); ++i) {
+            const auto* info = reg.get(static_cast<uint32_t>(i));
+            if (info && !info->id.empty() && info->type != "replicate") {
                 out << "  " << info->id << "  [" << info->type << "]\n";
             }
         }


### PR DESCRIPTION
## Summary
- Post-build merge of biological replicates within experiment groups using `--min-replicates N`
- Groups auto-inferred by stripping `_repNN` suffix from sample IDs, or set explicitly via manifest `group` column
- Expression averaged across replicates; reproducibility threshold capped at group size so singletons always survive

## Changes
- **sample_info.hpp**: Added `group` field with serialization and `with_group()` builder
- **sample_manifest.cpp**: Parse `group` column; auto-infer groups from `_repNN` suffix
- **genomic_feature.hpp**: Added `sample_bitset::clear()` and `expression_store::remove()` methods
- **builder.hpp/cpp**: Added `merge_replicates()` post-build step (walks caches, no tree traversal)
- **subcall.cpp**: Added `--min-replicates` CLI option (default: 0 = disabled)
- **index_stats.cpp**: Fixed display to properly count/hide replicate entries

## Test plan
- [x] Docker build compiles cleanly (gcc14)
- [x] `atroplex build -m test_manifest_small.tsv --stats` (no merge) — baseline output unchanged
- [x] `atroplex build -m test_manifest_small.tsv --stats --min-replicates 1` — singleton groups merged correctly
- [x] `atroplex build -m test_manifest.tsv --stats --min-replicates 2` — multi-replicate merging (4 reps → 2 groups + 1 annotation)
- [x] Stats header correctly shows `N replicates merged` and hides replicate entries from listing

🤖 Generated with [Claude Code](https://claude.com/claude-code)