### PR TITLE
Add tree depth tracking and TSV column documentation

### DIFF
--- a/include/index_stats.hpp
+++ b/include/index_stats.hpp
@@ -128,6 +128,10 @@ struct index_stats {
     static constexpr size_t MIN_HUB_BRANCHES = 10;
     static constexpr size_t MAX_DISPLAY_HUBS = 20;
 
+    // B+ tree structure
+    int tree_order = 0;
+    std::map<std::string, int> tree_depth_per_chromosome;  // per-index depth (root→leaf)
+
     // Per-chromosome summary
     struct chromosome_stats {
         size_t genes = 0;

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -176,6 +176,19 @@ index_stats builder::build_from_samples(grove_type& grove,
 
     stats.total_chromosomes = segment_caches.size();
     stats.total_segments = segment_count;
+    stats.tree_order = grove.get_order();
+
+    // Measure B+ tree depth per chromosome (root→leaf traversal)
+    for (const auto& [index_name, root_node] : grove.get_root_nodes()) {
+        int depth = 0;
+        auto* current = root_node;
+        while (current && !current->get_is_leaf()) {
+            current = current->get_children().empty() ? nullptr : current->get_children()[0];
+            depth++;
+        }
+        if (current) depth++;  // count the leaf level
+        stats.tree_depth_per_chromosome[index_name] = depth;
+    }
 
     // Gene info from segment features
     struct gene_stats_info {


### PR DESCRIPTION
## Summary
- Track per-chromosome B+ tree depth during grove construction and display in summary stats output
- Add `#`-prefixed comment headers to splicing_hubs.tsv, branch_details.tsv, and conserved_exons.tsv explaining column semantics (branches, shared, unique, transcripts, entropy, PSI, fraction, expression)

## Test plan
- [x] Build compiles cleanly
- [ ] Run `atroplex analyze` and verify comment headers appear at top of TSV files
- [ ] Verify tree depth values appear in per-chromosome summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)