### PR TITLE
Remove exon_caches dependency from discover/query/analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `[[nodiscard]]` to `segment_builder`, `transcript_matcher`, and `read_clusterer` return-value functions
 - Fixed `read_clusterer::stats::max_cluster_size` type from `double` to `size_t`
 
+### Refactored
+- Removed `exon_caches` dependency from `transcript_matcher` (#21): splice site indexing now walks the grove directly, enabling `--genogrove` for discover/query
+- Added `splicing_catalog::collect_from_grove()` (#21): reconstructs per-gene segment chains from grove traversal, enabling `--genogrove` for analyze
+
 ### Changed
 - **Read clustering**: replaced binned clustering with sort+sweep algorithm — eliminates boundary artifacts where reads 1bp apart could land in different bins and never be compared; sorts by `(strand, junction_count, first_donor)` then sweeps within `junction_tolerance`
 - Removed `--junction-bin` CLI option (binning is no longer used internally)

--- a/include/splicing_catalog.hpp
+++ b/include/splicing_catalog.hpp
@@ -73,6 +73,13 @@ public:
     );
 
     /**
+     * Build the catalog by walking the grove directly (no builder caches needed).
+     * Reconstructs per-gene segment chains from the grove's B+ tree and graph edges.
+     * Use this when loading from a .ggx file where builder caches are unavailable.
+     */
+    static std::vector<splicing_event> collect_from_grove(grove_type& grove);
+
+    /**
      * Write the splicing event catalog to TSV.
      * Columns: gene_id, gene_name, event_type, chromosome, upstream_exon,
      *          downstream_exon, affected_exon(s), per-sample PSI columns.

--- a/include/transcript_matcher.hpp
+++ b/include/transcript_matcher.hpp
@@ -197,9 +197,8 @@ public:
     };
 
     explicit transcript_matcher(grove_type& grove)
-        : transcript_matcher(grove, config{}, {}) {}
-    transcript_matcher(grove_type& grove, const config& cfg,
-                       const chromosome_exon_caches& exon_caches);
+        : transcript_matcher(grove, config{}) {}
+    transcript_matcher(grove_type& grove, const config& cfg);
 
     /**
      * Match a read cluster to reference transcripts
@@ -263,9 +262,9 @@ private:
     std::unordered_set<splice_site, splice_site_hash> known_acceptor_sites_;
 
     /**
-     * Build index of known splice sites from exon caches
+     * Build index of known splice sites by walking the grove
      */
-    void index_splice_sites(const chromosome_exon_caches& exon_caches);
+    void index_splice_sites();
 
     /**
      * Check if a splice site is known (within tolerance)

--- a/src/splicing_catalog.cpp
+++ b/src/splicing_catalog.cpp
@@ -57,6 +57,71 @@ std::vector<splicing_event> splicing_catalog::collect(
     return all_events;
 }
 
+std::vector<splicing_event> splicing_catalog::collect_from_grove(grove_type& grove) {
+    // Reconstruct gene_indices by walking the grove
+    chromosome_gene_segment_indices gene_indices;
+
+    auto roots = grove.get_root_nodes();
+    for (auto& [seqid, root] : roots) {
+        if (!root) continue;
+
+        auto* node = root;
+        while (!node->get_is_leaf()) {
+            auto& children = node->get_children();
+            if (children.empty()) break;
+            node = children[0];
+        }
+
+        while (node) {
+            for (auto* key : node->get_keys()) {
+                auto& feature = key->get_data();
+                if (!is_segment(feature)) continue;
+
+                auto& seg = get_segment(feature);
+                if (seg.absorbed) continue;
+
+                // Traverse exon chain
+                size_t edge_id = seg.segment_index;
+                std::vector<key_ptr> exon_chain;
+
+                auto first_exons = grove.get_neighbors_if(key,
+                    [edge_id](const edge_metadata& e) {
+                        return e.type == edge_metadata::edge_type::SEGMENT_TO_EXON
+                            && e.id == edge_id;
+                    });
+
+                if (!first_exons.empty()) {
+                    auto* current = first_exons.front();
+                    while (current) {
+                        exon_chain.push_back(current);
+                        auto next = grove.get_neighbors_if(current,
+                            [edge_id](const edge_metadata& e) {
+                                return e.type == edge_metadata::edge_type::EXON_TO_EXON
+                                    && e.id == edge_id;
+                            });
+                        current = next.empty() ? nullptr : next.front();
+                    }
+                }
+
+                // Build structure key from exon coordinates
+                std::string structure_key;
+                if (!exon_chain.empty()) {
+                    structure_key = format_coordinate(seqid, exon_chain.front()->get_value());
+                    for (size_t i = 1; i < exon_chain.size(); ++i) {
+                        structure_key += "," + format_coordinate(seqid, exon_chain[i]->get_value());
+                    }
+                }
+
+                gene_indices[seqid][seg.gene_id()].push_back(
+                    {key, std::move(exon_chain), std::move(structure_key)});
+            }
+            node = node->get_next();
+        }
+    }
+
+    return collect(gene_indices, grove);
+}
+
 std::vector<splicing_event> splicing_catalog::detect_gene_events(
     const std::string& gene_id,
     const std::string& chromosome,

--- a/src/subcall/analyze.cpp
+++ b/src/subcall/analyze.cpp
@@ -134,13 +134,15 @@ void analyze::execute(const cxxopts::ParseResult& args) {
         stats.write_splicing_hubs_tsv(hubs_path);
     }
 
-    // Splicing event catalog (requires gene_indices from build)
-    if (!gene_indices_.empty()) {
+    // Splicing event catalog
+    {
         auto events_dir = analysis_dir / "splicing_events";
         std::filesystem::create_directories(events_dir);
 
         logging::info("Detecting alternative splicing events...");
-        auto events = splicing_catalog::collect(gene_indices_, *grove);
+        auto events = gene_indices_.empty()
+            ? splicing_catalog::collect_from_grove(*grove)
+            : splicing_catalog::collect(gene_indices_, *grove);
         logging::info("Found " + std::to_string(events.size()) + " splicing events");
 
         std::string events_path = (events_dir / (basename + ".splicing_events.tsv")).string();

--- a/src/subcall/discover.cpp
+++ b/src/subcall/discover.cpp
@@ -150,7 +150,7 @@ void discover::process_reads(const cxxopts::ParseResult& args) {
     match_cfg.min_junction_score = min_junction_score;
     match_cfg.min_overlap_bp = min_overlap_bp;
 
-    transcript_matcher matcher(*grove, match_cfg, exon_caches_);
+    transcript_matcher matcher(*grove, match_cfg);
     auto results = matcher.match_batch(clusters);
 
     // Step 3: Update grove with read support

--- a/src/subcall/query.cpp
+++ b/src/subcall/query.cpp
@@ -192,7 +192,7 @@ std::vector<query_result> query::classify_transcripts(const std::string& input_p
     match_cfg.min_junction_score = 0.8;
     match_cfg.min_overlap_bp = 50;
 
-    transcript_matcher matcher(*grove, match_cfg, exon_caches_);
+    transcript_matcher matcher(*grove, match_cfg);
 
     // Read input GTF/GFF gene-by-gene and classify each transcript
     gio::gff_reader reader(input_path);

--- a/src/transcript_matcher.cpp
+++ b/src/transcript_matcher.cpp
@@ -80,32 +80,71 @@ std::string match_result::category_string() const {
 // transcript_matcher implementation
 // ============================================================================
 
-transcript_matcher::transcript_matcher(grove_type& grove, const config& cfg,
-                                       const chromosome_exon_caches& exon_caches)
+transcript_matcher::transcript_matcher(grove_type& grove, const config& cfg)
     : grove_(grove), cfg_(cfg) {
-    // Index known splice sites from exon caches
-    index_splice_sites(exon_caches);
+    index_splice_sites();
 }
 
-void transcript_matcher::index_splice_sites(const chromosome_exon_caches& exon_caches) {
+void transcript_matcher::index_splice_sites() {
     size_t donor_count = 0;
     size_t acceptor_count = 0;
+    size_t chromosomes = 0;
 
-    for (const auto& [seqid, exon_cache] : exon_caches) {
-        for (const auto& [coord, exon_ptr] : exon_cache) {
-            // Donor = exon end (5' splice site of downstream intron)
-            known_donor_sites_.insert({seqid, coord.get_end()});
-            ++donor_count;
+    // Walk grove segments and traverse exon chains to collect splice sites
+    auto roots = grove_.get_root_nodes();
+    for (auto& [seqid, root] : roots) {
+        if (!root) continue;
+        chromosomes++;
 
-            // Acceptor = exon start (3' splice site of upstream intron)
-            known_acceptor_sites_.insert({seqid, coord.get_start()});
-            ++acceptor_count;
+        auto* node = root;
+        while (!node->get_is_leaf()) {
+            auto& children = node->get_children();
+            if (children.empty()) break;
+            node = children[0];
+        }
+
+        while (node) {
+            for (auto* key : node->get_keys()) {
+                auto& feature = key->get_data();
+                if (!is_segment(feature)) continue;
+
+                auto& seg = get_segment(feature);
+                if (seg.absorbed) continue;
+
+                size_t edge_id = seg.segment_index;
+
+                // Walk SEGMENT_TO_EXON → EXON_TO_EXON chain
+                auto first_exons = grove_.get_neighbors_if(key,
+                    [edge_id](const edge_metadata& e) {
+                        return e.type == edge_metadata::edge_type::SEGMENT_TO_EXON
+                            && e.id == edge_id;
+                    });
+
+                if (first_exons.empty()) continue;
+
+                auto* current = first_exons.front();
+                while (current) {
+                    auto& coord = current->get_value();
+                    known_donor_sites_.insert({seqid, coord.get_end()});
+                    ++donor_count;
+                    known_acceptor_sites_.insert({seqid, coord.get_start()});
+                    ++acceptor_count;
+
+                    auto next = grove_.get_neighbors_if(current,
+                        [edge_id](const edge_metadata& e) {
+                            return e.type == edge_metadata::edge_type::EXON_TO_EXON
+                                && e.id == edge_id;
+                        });
+                    current = next.empty() ? nullptr : next.front();
+                }
+            }
+            node = node->get_next();
         }
     }
 
     logging::info("Indexed " + std::to_string(donor_count) + " donor and " +
                   std::to_string(acceptor_count) + " acceptor splice sites from " +
-                  std::to_string(exon_caches.size()) + " chromosome(s)");
+                  std::to_string(chromosomes) + " chromosome(s)");
 }
 
 bool transcript_matcher::is_known_donor(const std::string& seqid, size_t position) const {

--- a/tests/discover/sqanti_category_test.cpp
+++ b/tests/discover/sqanti_category_test.cpp
@@ -78,7 +78,7 @@ protected:
                           int min_overlap = 50) {
         transcript_matcher::config cfg;
         cfg.min_overlap_bp = min_overlap;
-        transcript_matcher matcher(*grove, cfg, exon_caches);
+        transcript_matcher matcher(*grove, cfg);
         return matcher.match(cluster);
     }
 
@@ -238,7 +238,7 @@ TEST_F(DiscoverCategoryTest, FSM_GeneB) {
 TEST_F(DiscoverCategoryTest, MatcherStats_TrackAllCategories) {
     transcript_matcher::config cfg;
     cfg.min_overlap_bp = 1;
-    transcript_matcher matcher(*grove, cfg, exon_caches);
+    transcript_matcher matcher(*grove, cfg);
 
     // FSM
     [[maybe_unused]] auto fsm_result = matcher.match(make_cluster("fsm", "chr22", '+', 10000, 14500,
@@ -261,7 +261,7 @@ TEST_F(DiscoverCategoryTest, MatcherStats_TrackAllCategories) {
 TEST_F(DiscoverCategoryTest, UpdateGrove_ReadCoverageOnMatchedSegment) {
     transcript_matcher::config cfg;
     cfg.min_overlap_bp = 1;
-    transcript_matcher matcher(*grove, cfg, exon_caches);
+    transcript_matcher matcher(*grove, cfg);
 
     // Create cluster matching TX_A1 (FSM) with 5 reads
     auto cluster = make_cluster("fsm_cov", "chr22", '+', 10000, 14500,
@@ -299,7 +299,7 @@ TEST_F(DiscoverCategoryTest, UpdateGrove_ReadCoverageOnMatchedSegment) {
 TEST_F(DiscoverCategoryTest, UpdateGrove_ReadCoverageAccumulates) {
     transcript_matcher::config cfg;
     cfg.min_overlap_bp = 1;
-    transcript_matcher matcher(*grove, cfg, exon_caches);
+    transcript_matcher matcher(*grove, cfg);
 
     // First cluster: 3 reads matching TX_A1
     auto cluster1 = make_cluster("batch1", "chr22", '+', 10000, 14500,
@@ -489,7 +489,7 @@ TEST_F(DiscoverIntegrationTest, FullPipeline_AllCategories) {
 
     transcript_matcher::config match_cfg;
     match_cfg.min_overlap_bp = 1;
-    transcript_matcher matcher(*grove, match_cfg, exon_caches);
+    transcript_matcher matcher(*grove, match_cfg);
     auto results = matcher.match_batch(clusters);
 
     ASSERT_EQ(results.size(), clusters.size());
@@ -528,7 +528,7 @@ TEST_F(DiscoverIntegrationTest, FullPipeline_NovelJunctionsDetected) {
 
     transcript_matcher::config match_cfg;
     match_cfg.min_overlap_bp = 1;
-    transcript_matcher matcher(*grove, match_cfg, exon_caches);
+    transcript_matcher matcher(*grove, match_cfg);
     auto results = matcher.match_batch(clusters);
 
     // NNC cluster should report novel donors (11500 is not near any known donor)

--- a/tests/query/query_classification_test.cpp
+++ b/tests/query/query_classification_test.cpp
@@ -96,7 +96,7 @@ protected:
         cfg.junction_tolerance = 5;
         cfg.min_junction_score = 0.8;
         cfg.min_overlap_bp = 50;
-        transcript_matcher matcher(*grove, cfg, exon_caches);
+        transcript_matcher matcher(*grove, cfg);
 
         gio::gff_reader reader(query_path);
 


### PR DESCRIPTION
## Summary
- `transcript_matcher` no longer requires `exon_caches` — extracts splice site positions directly from the grove by walking segment → exon chains
- `splicing_catalog` gains `collect_from_grove()` — reconstructs per-gene segment chains from the grove's B+ tree and graph edges
- `analyze` falls back to `collect_from_grove()` when `gene_indices_` is empty (i.e., when loaded from `.ggx`)
- **Enables `--genogrove` to work with discover, query, and analyze** — previously these silently used empty caches

### What changed
| Component | Before | After |
|---|---|---|
| `transcript_matcher` constructor | `(grove, cfg, exon_caches)` | `(grove, cfg)` |
| `index_splice_sites()` | Walked `exon_caches` map | Walks grove B+ tree + graph edges |
| `splicing_catalog::collect()` | Only from `gene_indices_` | Also `collect_from_grove()` for .ggx |
| `analyze` splicing catalog | Skipped if `gene_indices_` empty | Falls back to grove traversal |

### Build-time caches unchanged
`exon_caches_` and `gene_indices_` are still populated during `build_from_samples()` for build-time deduplication and absorption. They just aren't required by downstream consumers anymore.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] Project builds successfully in CLion
- [x] All CI checks pass (GCC 13/14, Clang 18, macOS)
- [x] All tests pass (absorption, discover, query, serialization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)