### PR TITLE
Fix build hang after Grove construction; add --prune-tombstones opt-in

### DIFF
--- a/include/builder.hpp
+++ b/include/builder.hpp
@@ -55,6 +55,7 @@ public:
         bool absorb = true,
         int min_replicates = 0,
         size_t fuzzy_tolerance = 5,
+        bool prune_tombstones = false,
         chromosome_exon_caches* out_exon_caches = nullptr,
         chromosome_gene_segment_indices* out_gene_indices = nullptr
     );
@@ -89,15 +90,22 @@ private:
         int min_replicates
     );
 
-    /// Physically remove absorbed (tombstoned) segments from the grove.
-    /// Drops the segment keys from the B+ tree, clears orphan EXON_TO_EXON
-    /// edges carrying the tombstone's segment_index, and prunes the
-    /// segment_caches and gene_indices of stale entries. Returns the number
-    /// of tombstones removed.
+    /// Handle absorbed (tombstoned) segments after the build.
+    /// Always counts tombstones, prunes them from segment_caches and
+    /// gene_indices, and returns the count.
+    ///
+    /// When `physical == true`, additionally unlinks the tombstoned keys
+    /// from the B+ tree via grove.remove_key() and drops orphan
+    /// EXON_TO_EXON chain edges. This produces a smaller .ggx at the
+    /// cost of an O(N × E) sweep (genogrove's graph_overlay::remove_edges_to
+    /// is O(E) per call), which can block for minutes to hours on
+    /// realistic indices. Default `false` — tombstones stay in the tree
+    /// and every consumer already filters them defensively.
     static size_t remove_tombstones(
         grove_type& grove,
         chromosome_segment_caches& segment_caches,
-        chromosome_gene_segment_indices& gene_indices
+        chromosome_gene_segment_indices& gene_indices,
+        bool physical
     );
 };
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -330,43 +330,40 @@ size_t builder::merge_replicates(
 }
 
 size_t builder::remove_tombstones(
-    grove_type& grove,
+    grove_type& /*grove*/,
     chromosome_segment_caches& segment_caches,
     chromosome_gene_segment_indices& gene_indices
 ) {
-    // Note: try_reverse_absorption already erases absorbed segments from
-    // segment_cache at the moment it tombstones them (segment_builder.cpp:367).
-    // gene_indices retains absorbed entries, so it's the authoritative source
-    // of tombstones that still live in the B+ tree.
-    std::unordered_set<size_t> tombstone_ids;
+    // Physical removal via grove.remove_key() is O(N × E) because
+    // genogrove's graph_overlay::remove_edges_to scans the full adjacency
+    // map on every call (even though segments are never edge targets, so
+    // the scan always finds zero matches). On realistic indices this
+    // blocks the build for hours after "Grove construction complete".
+    //
+    // For now we only COUNT tombstones and prune them from segment_caches
+    // and gene_indices so downstream summary collection doesn't see them.
+    // The tombstoned keys themselves stay in the B+ tree; every consumer
+    // already skips them defensively via `if (seg.absorbed) continue;`.
+    // This wastes a bit of memory (and bloats the serialized .ggx) but
+    // keeps the build moving. See TODO: replace with a batch-removal
+    // genogrove API that skips the incoming-edge scan when segments are
+    // known to be edge-source-only.
+
     size_t removed = 0;
 
+    // Count absorbed entries via the authoritative source (gene_indices).
     for (auto& [seqid, gene_idx] : gene_indices) {
         for (auto& [gene_id, entries] : gene_idx) {
             for (auto& entry : entries) {
                 auto& feature = entry.segment->get_data();
                 if (!is_segment(feature)) continue;
-                auto& seg = get_segment(feature);
-                if (!seg.absorbed) continue;
-
-                tombstone_ids.insert(seg.segment_index);
-                grove.remove_key(seqid, entry.segment);
-                ++removed;
+                if (get_segment(feature).absorbed) ++removed;
             }
         }
     }
 
-    // Drop orphan EXON_TO_EXON edges that carry a tombstone's segment_index.
-    // remove_key only removes edges where the segment key itself is source
-    // or target; chain edges between exon keys are not touched automatically.
-    if (!tombstone_ids.empty()) {
-        grove.remove_edges_if([&tombstone_ids](const auto& e) {
-            return tombstone_ids.count(e.metadata.id) > 0;
-        });
-    }
-
-    // Prune gene_indices entries that reference removed segments so that
-    // downstream stats collection never sees a tombstone.
+    // Prune absorbed entries from gene_indices so that downstream stats
+    // collection never sees a tombstone.
     for (auto& [seqid, gene_idx] : gene_indices) {
         for (auto& [gene_id, entries] : gene_idx) {
             std::erase_if(entries, [](const segment_chain_entry& e) {
@@ -375,9 +372,8 @@ size_t builder::remove_tombstones(
         }
     }
 
-    // Safety net: if any code path ever leaves an absorbed entry in segment_cache
-    // without erasing it (try_reverse_absorption does erase, but forward
-    // absorption rules don't go through that code), drop those too.
+    // Safety net: try_reverse_absorption already erases from segment_cache
+    // at the moment it tombstones, but drop any stragglers defensively.
     for (auto& [seqid, seg_cache] : segment_caches) {
         for (auto it = seg_cache.begin(); it != seg_cache.end(); ) {
             auto& feature = it->second->get_data();
@@ -390,8 +386,9 @@ size_t builder::remove_tombstones(
     }
 
     if (removed > 0) {
-        logging::info("Removed " + std::to_string(removed) +
-            " absorbed (tombstoned) segments from grove");
+        logging::info("Counted " + std::to_string(removed) +
+            " absorbed (tombstoned) segments; physical removal deferred "
+            "pending a batch genogrove remove_key variant");
     }
 
     return removed;

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -52,6 +52,7 @@ build_summary builder::build_from_samples(grove_type& grove,
                                   bool absorb,
                                   int min_replicates,
                                   size_t fuzzy_tolerance,
+                                  bool prune_tombstones,
                                   chromosome_exon_caches* out_exon_caches,
                                   chromosome_gene_segment_indices* out_gene_indices) {
     if (samples.empty()) {
@@ -178,8 +179,9 @@ build_summary builder::build_from_samples(grove_type& grove,
         counters.replicates_merged = merge_replicates(exon_caches, segment_caches, min_replicates);
     }
 
-    // --- Physically remove absorbed segments from the grove ---
-    counters.absorbed_segments = remove_tombstones(grove, segment_caches, gene_indices);
+    // --- Count (and optionally physically remove) absorbed segments ---
+    counters.absorbed_segments = remove_tombstones(
+        grove, segment_caches, gene_indices, prune_tombstones);
 
     // --- Collect summary statistics ---
     build_summary stats;
@@ -330,40 +332,56 @@ size_t builder::merge_replicates(
 }
 
 size_t builder::remove_tombstones(
-    grove_type& /*grove*/,
+    grove_type& grove,
     chromosome_segment_caches& segment_caches,
-    chromosome_gene_segment_indices& gene_indices
+    chromosome_gene_segment_indices& gene_indices,
+    bool physical
 ) {
-    // Physical removal via grove.remove_key() is O(N × E) because
-    // genogrove's graph_overlay::remove_edges_to scans the full adjacency
-    // map on every call (even though segments are never edge targets, so
-    // the scan always finds zero matches). On realistic indices this
-    // blocks the build for hours after "Grove construction complete".
+    // Phase 1 (always): walk gene_indices, count tombstones, and (when
+    // physical == true) issue grove.remove_key calls while we have the
+    // seqid + key pointer handy. We also collect the tombstone
+    // segment_indices so the orphan-edge sweep below can drop EXON_TO_EXON
+    // chain edges that carry a dead id.
     //
-    // For now we only COUNT tombstones and prune them from segment_caches
-    // and gene_indices so downstream summary collection doesn't see them.
-    // The tombstoned keys themselves stay in the B+ tree; every consumer
-    // already skips them defensively via `if (seg.absorbed) continue;`.
-    // This wastes a bit of memory (and bloats the serialized .ggx) but
-    // keeps the build moving. See TODO: replace with a batch-removal
-    // genogrove API that skips the incoming-edge scan when segments are
-    // known to be edge-source-only.
-
+    // Note on the physical path cost: each grove.remove_key() call fans
+    // out into genogrove's graph_overlay::remove_edges_to, which is O(E)
+    // (full adjacency scan). Segments are never edge targets, so the
+    // scan always finds zero matches but still pays the full cost — that
+    // makes the total sweep O(N × E) and can block builds for minutes
+    // to hours on realistic indices. Gated behind --prune-tombstones so
+    // callers opt in when they want a clean distributable .ggx.
+    std::unordered_set<size_t> tombstone_ids;
     size_t removed = 0;
 
-    // Count absorbed entries via the authoritative source (gene_indices).
     for (auto& [seqid, gene_idx] : gene_indices) {
         for (auto& [gene_id, entries] : gene_idx) {
             for (auto& entry : entries) {
                 auto& feature = entry.segment->get_data();
                 if (!is_segment(feature)) continue;
-                if (get_segment(feature).absorbed) ++removed;
+                auto& seg = get_segment(feature);
+                if (!seg.absorbed) continue;
+
+                ++removed;
+                if (physical) {
+                    tombstone_ids.insert(seg.segment_index);
+                    grove.remove_key(seqid, entry.segment);
+                }
             }
         }
     }
 
-    // Prune absorbed entries from gene_indices so that downstream stats
-    // collection never sees a tombstone.
+    // Phase 2 (physical only): one pass to drop orphan EXON_TO_EXON
+    // edges carrying a tombstone's segment_index. remove_key only
+    // handles edges where the segment key itself is source or target;
+    // chain edges between exon keys are not touched automatically.
+    if (physical && !tombstone_ids.empty()) {
+        grove.remove_edges_if([&tombstone_ids](const auto& e) {
+            return tombstone_ids.count(e.metadata.id) > 0;
+        });
+    }
+
+    // Phase 3 (always): prune absorbed entries from gene_indices so that
+    // downstream stats collection never sees a tombstone.
     for (auto& [seqid, gene_idx] : gene_indices) {
         for (auto& [gene_id, entries] : gene_idx) {
             std::erase_if(entries, [](const segment_chain_entry& e) {
@@ -372,8 +390,9 @@ size_t builder::remove_tombstones(
         }
     }
 
-    // Safety net: try_reverse_absorption already erases from segment_cache
-    // at the moment it tombstones, but drop any stragglers defensively.
+    // Phase 4 (always): safety net on segment_caches. try_reverse_absorption
+    // already erases from segment_cache at the moment it tombstones, but
+    // drop any stragglers defensively.
     for (auto& [seqid, seg_cache] : segment_caches) {
         for (auto it = seg_cache.begin(); it != seg_cache.end(); ) {
             auto& feature = it->second->get_data();
@@ -386,9 +405,14 @@ size_t builder::remove_tombstones(
     }
 
     if (removed > 0) {
-        logging::info("Counted " + std::to_string(removed) +
-            " absorbed (tombstoned) segments; physical removal deferred "
-            "pending a batch genogrove remove_key variant");
+        if (physical) {
+            logging::info("Pruned " + std::to_string(removed) +
+                " absorbed (tombstoned) segments from grove");
+        } else {
+            logging::info("Counted " + std::to_string(removed) +
+                " absorbed (tombstoned) segments; tombstones kept in grove "
+                "(pass --prune-tombstones for physical removal)");
+        }
     }
 
     return removed;
@@ -415,5 +439,5 @@ build_summary builder::build_from_files(grove_type& grove,
         samples.push_back(std::move(info));
     }
 
-    return build_from_samples(grove, samples, threads, -1.0f, true, 0, 5, out_exon_caches);
+    return build_from_samples(grove, samples, threads, -1.0f, true, 0, 5, false, out_exon_caches);
 }

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -172,8 +172,6 @@ build_summary builder::build_from_samples(grove_type& grove,
         }
     }
 
-    logging::info("Grove construction complete: " + std::to_string(segment_count) + " segments");
-
     // --- Post-build replicate merging ---
     if (min_replicates > 0) {
         counters.replicates_merged = merge_replicates(exon_caches, segment_caches, min_replicates);
@@ -182,6 +180,18 @@ build_summary builder::build_from_samples(grove_type& grove,
     // --- Count (and optionally physically remove) absorbed segments ---
     counters.absorbed_segments = remove_tombstones(
         grove, segment_caches, gene_indices, prune_tombstones);
+
+    // Live segments = total minus tombstones that were reverse-absorbed.
+    size_t live_segments = (segment_count >= counters.absorbed_segments)
+        ? segment_count - counters.absorbed_segments
+        : segment_count;
+    std::string tombstone_note;
+    if (counters.absorbed_segments > 0) {
+        tombstone_note = " (" + std::to_string(counters.absorbed_segments)
+            + (prune_tombstones ? " tombstones pruned)" : " tombstones)");
+    }
+    logging::info("Grove construction complete: " + std::to_string(live_segments)
+        + " segments" + tombstone_note);
 
     // --- Collect summary statistics ---
     build_summary stats;
@@ -401,17 +411,6 @@ size_t builder::remove_tombstones(
             } else {
                 ++it;
             }
-        }
-    }
-
-    if (removed > 0) {
-        if (physical) {
-            logging::info("Pruned " + std::to_string(removed) +
-                " absorbed (tombstoned) segments from grove");
-        } else {
-            logging::info("Counted " + std::to_string(removed) +
-                " absorbed (tombstoned) segments; tombstones kept in grove "
-                "(pass --prune-tombstones for physical removal)");
         }
     }
 

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -48,6 +48,9 @@ void subcall::add_common_options(cxxopts::Options& options) {
             cxxopts::value<size_t>()->default_value("5"))
         ("min-replicates", "Merge biological replicates within groups; require features in >= N replicates (0 = no merge)",
             cxxopts::value<int>()->default_value("0"))
+        ("prune-tombstones", "Physically remove absorbed (tombstoned) segments from the grove after build. "
+            "Produces a smaller/cleaner .ggx at the cost of a slow post-build sweep "
+            "(grove.remove_key is O(E) per call today). Default: off — tombstones stay in the tree and are filtered at query time.")
         ;
 }
 
@@ -126,6 +129,7 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         bool absorb = !args.count("no-absorb");
         size_t fuzzy_tol = args["fuzzy-tolerance"].as<size_t>();
         int min_reps = args["min-replicates"].as<int>();
+        bool prune_tombstones = args.count("prune-tombstones") > 0;
         logging::info("Creating grove with order: " + std::to_string(order));
         if (min_expr >= 0) {
             logging::info("Filtering transcripts with expression < " + std::to_string(min_expr));
@@ -138,9 +142,12 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         if (min_reps > 0) {
             logging::info("Replicate merging enabled: min_replicates = " + std::to_string(min_reps));
         }
+        if (prune_tombstones) {
+            logging::info("Physical tombstone removal enabled (--prune-tombstones)");
+        }
         grove = std::make_unique<grove_type>(order);
         auto build_start = std::chrono::steady_clock::now();
-        build_stats = builder::build_from_samples(*grove, all_samples, threads, min_expr, absorb, min_reps, fuzzy_tol, &exon_caches_, &gene_indices_);
+        build_stats = builder::build_from_samples(*grove, all_samples, threads, min_expr, absorb, min_reps, fuzzy_tol, prune_tombstones, &exon_caches_, &gene_indices_);
         auto build_elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - build_start).count();
         build_stats->build_time_seconds = build_elapsed;
         logging::info("Grove ready with spatial index and graph structure");

--- a/tests/build/builder_pipeline_test.cpp
+++ b/tests/build/builder_pipeline_test.cpp
@@ -3,8 +3,10 @@
  * remove_tombstones(), build_counters aggregation, and build_summary::collect /
  * write_summary.
  *
- * These exercise the orchestration layer that sits on top of build_gff / build_bam,
- * which the other test suites bypass by calling build_gff::build directly.
+ * These exercise the orchestration layer that sits on top of build_gff /
+ * build_bam, which the other test suites bypass by calling build_gff::build
+ * directly. Covers both the default tombstone-kept-in-tree path and the
+ * --prune-tombstones physical-removal path.
  */
 
 #include <gtest/gtest.h>
@@ -16,7 +18,6 @@
 #include <string>
 #include <vector>
 
-#include "build_gff.hpp"
 #include "build_summary.hpp"
 #include "builder.hpp"
 #include "genomic_feature.hpp"
@@ -173,21 +174,15 @@ TEST_F(BuilderPipelineTest, BuilderFullPipeline_CountersPopulated) {
     EXPECT_EQ(summary.total_genes, 1u);
 }
 
-// ── Tier 1.2: Tombstones are counted and pruned from caches ────────────────
+// ── Tier 1.2: default (no --prune-tombstones) counts but keeps in tree ─────
 //
-// remove_tombstones currently counts absorbed segments and prunes them
-// from segment_caches and gene_indices so downstream stats collection
-// never sees a tombstone. Physical removal from the B+ tree is deferred
-// pending a batch genogrove remove_key variant — grove.remove_key() is
-// O(E) per call today, and calling it per tombstone makes the sweep
-// O(N × E) which blocks realistic builds for hours.
-//
-// Verified here:
-//   - counters.absorbed_segments is populated
-//   - total_segments subtracts tombstones (= segment_count - absorbed)
-//   - the segment_feature with absorbed=true DOES remain in the tree
-//     (this is the temporary trade-off we accept)
-TEST_F(BuilderPipelineTest, RemoveTombstones_CountedNotRemoved) {
+// Default behavior: tombstones are counted and pruned from segment_caches
+// and gene_indices so downstream stats never see them, but the segment
+// keys remain physically in the B+ tree. All grove consumers defensively
+// filter `seg.absorbed`, so this is correctness-safe — the tradeoff is
+// a bit of memory / .ggx size. Opt into the slow path with
+// --prune-tombstones when producing a distributable index.
+TEST_F(BuilderPipelineTest, RemoveTombstones_DefaultKeepsInTree) {
     auto ism_path = write_ism_gtf();
     auto parent_path = write_parent_gtf();
 
@@ -198,22 +193,22 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_CountedNotRemoved) {
     samples.back().type = "sample";
 
     grove_type grove(3);
+    // prune_tombstones = false (default)
     auto summary = builder::build_from_samples(
-        grove, samples, 1, -1.0f, true, 0, 5);
+        grove, samples,
+        /*threads=*/1, /*min_expression=*/-1.0f, /*absorb=*/true,
+        /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+        /*prune_tombstones=*/false);
 
-    // Counter is populated and total_segments subtracts it
     ASSERT_EQ(summary.counters.absorbed_segments, 1u)
         << "Fixture must produce exactly one tombstone";
     EXPECT_EQ(summary.total_segments, 1u)
         << "total_segments should subtract tombstones";
 
-    // Tombstoned segment stays in the tree (current behavior). Walk the
-    // B+ tree and confirm we find BOTH segments — parent (absorbed=false)
-    // and the tombstoned ISM (absorbed=true).
     auto live = walk_live_segments(grove);
     EXPECT_EQ(live.size(), 2u)
-        << "Both segments still present in B+ tree until batch "
-           "genogrove removal lands";
+        << "Default: both segments still present in B+ tree "
+           "(opt into --prune-tombstones for physical removal)";
 
     size_t absorbed_in_tree = 0;
     size_t live_in_tree = 0;
@@ -225,21 +220,53 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_CountedNotRemoved) {
     EXPECT_EQ(live_in_tree, 1u);
 }
 
-// ── Tier 1.3: Orphan EXON_TO_EXON edges are pruned by the sweep ────────────
+// ── Tier 1.2b: --prune-tombstones physically removes the key ───────────────
 //
-// Disabled until physical tombstone removal is re-enabled (blocked on
-// batch genogrove remove_key variant — see remove_tombstones() comment).
-// With the current counter-only sweep the swept and unswept edge counts
-// are identical, which this test would report as a failure.
-//
-// When the physical removal returns, rename back to
-// `RemoveTombstones_OrphanEdgesPruned` and re-enable.
-TEST_F(BuilderPipelineTest, DISABLED_RemoveTombstones_OrphanEdgesPruned) {
+// When the flag is set, remove_tombstones calls grove.remove_key() per
+// tombstone and runs a remove_edges_if pass to drop orphan EXON_TO_EXON
+// chain edges. The tombstoned segment should no longer surface in a tree
+// walk, and the edge count should drop.
+TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagPhysicallyRemoves) {
     auto ism_path = write_ism_gtf();
     auto parent_path = write_parent_gtf();
 
-    // Build A: full builder pipeline (sweep runs)
-    size_t swept_edge_count = 0;
+    std::vector<sample_info> samples;
+    samples.emplace_back("ism_sample", ism_path);
+    samples.back().type = "sample";
+    samples.emplace_back("parent_sample", parent_path);
+    samples.back().type = "sample";
+
+    grove_type grove(3);
+    auto summary = builder::build_from_samples(
+        grove, samples,
+        /*threads=*/1, /*min_expression=*/-1.0f, /*absorb=*/true,
+        /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+        /*prune_tombstones=*/true);
+
+    ASSERT_EQ(summary.counters.absorbed_segments, 1u);
+
+    auto live = walk_live_segments(grove);
+    EXPECT_EQ(live.size(), 1u)
+        << "Expected exactly one live segment (parent) after pruning";
+    for (const auto* seg : live) {
+        EXPECT_FALSE(seg->absorbed)
+            << "Tree traversal should not surface any absorbed segment "
+               "when --prune-tombstones is set";
+    }
+}
+
+// ── Tier 1.3: --prune-tombstones drops orphan EXON_TO_EXON edges ───────────
+//
+// Under --prune-tombstones, remove_tombstones calls remove_edges_if to
+// strip chain edges whose metadata.id matches a tombstoned
+// segment_index. Verified by comparing the edge count of a pruned grove
+// against a non-pruned baseline built from the same files.
+TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
+    auto ism_path = write_ism_gtf();
+    auto parent_path = write_parent_gtf();
+
+    // Build A: --prune-tombstones ON
+    size_t pruned_edge_count = 0;
     {
         std::vector<sample_info> samples;
         samples.emplace_back("ism_sample", ism_path);
@@ -249,48 +276,42 @@ TEST_F(BuilderPipelineTest, DISABLED_RemoveTombstones_OrphanEdgesPruned) {
 
         grove_type grove(3);
         auto summary = builder::build_from_samples(
-            grove, samples, 1, -1.0f, true, 0, 5);
+            grove, samples,
+            /*threads=*/1, /*min_expression=*/-1.0f, /*absorb=*/true,
+            /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+            /*prune_tombstones=*/true);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
-        swept_edge_count = grove.edge_count();
+        pruned_edge_count = grove.edge_count();
     }
 
-    // Build B: bypass the sweep by calling build_gff::build directly
-    // twice against the same caches. Tombstone remains in place with its
-    // orphan edges.
-    size_t unswept_edge_count = 0;
+    // Build B: --prune-tombstones OFF (default) — orphan edges remain
+    size_t default_edge_count = 0;
     {
-        // Clear registries so sample IDs start at 0 again
         transcript_registry::reset();
         gene_registry::reset();
         source_registry::reset();
         sample_registry::reset();
 
+        std::vector<sample_info> samples;
+        samples.emplace_back("ism_sample", ism_path);
+        samples.back().type = "sample";
+        samples.emplace_back("parent_sample", parent_path);
+        samples.back().type = "sample";
+
         grove_type grove(3);
-        chromosome_exon_caches exon_caches;
-        chromosome_segment_caches segment_caches;
-        chromosome_gene_segment_indices gene_indices;
-        size_t segment_count = 0;
-        build_counters counters;
-
-        sample_info ism_info("ism_sample", ism_path);
-        ism_info.type = "sample";
-        uint32_t ism_id = sample_registry::instance().register_data(ism_info);
-        build_gff::build(grove, ism_path, ism_id, exon_caches, segment_caches,
-                         gene_indices, segment_count, 0, -1.0f, true, 5, counters);
-
-        sample_info parent_info("parent_sample", parent_path);
-        parent_info.type = "sample";
-        uint32_t parent_id = sample_registry::instance().register_data(parent_info);
-        build_gff::build(grove, parent_path, parent_id, exon_caches, segment_caches,
-                         gene_indices, segment_count, 0, -1.0f, true, 5, counters);
-
-        unswept_edge_count = grove.edge_count();
+        auto summary = builder::build_from_samples(
+            grove, samples,
+            /*threads=*/1, /*min_expression=*/-1.0f, /*absorb=*/true,
+            /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+            /*prune_tombstones=*/false);
+        ASSERT_EQ(summary.counters.absorbed_segments, 1u);
+        default_edge_count = grove.edge_count();
     }
 
-    EXPECT_LT(swept_edge_count, unswept_edge_count)
-        << "Sweep should have removed at least one orphan edge. "
-        << "Swept: " << swept_edge_count
-        << ", unswept: " << unswept_edge_count;
+    EXPECT_LT(pruned_edge_count, default_edge_count)
+        << "--prune-tombstones should have removed at least one orphan edge. "
+        << "Pruned: " << pruned_edge_count
+        << ", default: " << default_edge_count;
 }
 
 // ── Tier 1.4: build_summary text file contains the processing section ─────

--- a/tests/build/builder_pipeline_test.cpp
+++ b/tests/build/builder_pipeline_test.cpp
@@ -173,12 +173,21 @@ TEST_F(BuilderPipelineTest, BuilderFullPipeline_CountersPopulated) {
     EXPECT_EQ(summary.total_genes, 1u);
 }
 
-// ── Tier 1.2: Physical removal of tombstones from the B+ tree ──────────────
+// ── Tier 1.2: Tombstones are counted and pruned from caches ────────────────
 //
-// After the sweep runs, no segment in live tree traversal should have
-// absorbed == true. This confirms remove_tombstones() actually unlinks
-// keys from the tree (rather than leaving them as stale entries).
-TEST_F(BuilderPipelineTest, RemoveTombstones_PhysicallyRemoved) {
+// remove_tombstones currently counts absorbed segments and prunes them
+// from segment_caches and gene_indices so downstream stats collection
+// never sees a tombstone. Physical removal from the B+ tree is deferred
+// pending a batch genogrove remove_key variant — grove.remove_key() is
+// O(E) per call today, and calling it per tombstone makes the sweep
+// O(N × E) which blocks realistic builds for hours.
+//
+// Verified here:
+//   - counters.absorbed_segments is populated
+//   - total_segments subtracts tombstones (= segment_count - absorbed)
+//   - the segment_feature with absorbed=true DOES remain in the tree
+//     (this is the temporary trade-off we accept)
+TEST_F(BuilderPipelineTest, RemoveTombstones_CountedNotRemoved) {
     auto ism_path = write_ism_gtf();
     auto parent_path = write_parent_gtf();
 
@@ -192,27 +201,40 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PhysicallyRemoved) {
     auto summary = builder::build_from_samples(
         grove, samples, 1, -1.0f, true, 0, 5);
 
+    // Counter is populated and total_segments subtracts it
     ASSERT_EQ(summary.counters.absorbed_segments, 1u)
         << "Fixture must produce exactly one tombstone";
+    EXPECT_EQ(summary.total_segments, 1u)
+        << "total_segments should subtract tombstones";
 
+    // Tombstoned segment stays in the tree (current behavior). Walk the
+    // B+ tree and confirm we find BOTH segments — parent (absorbed=false)
+    // and the tombstoned ISM (absorbed=true).
     auto live = walk_live_segments(grove);
-    EXPECT_EQ(live.size(), 1u)
-        << "Expected exactly one live segment (the parent) after sweep";
+    EXPECT_EQ(live.size(), 2u)
+        << "Both segments still present in B+ tree until batch "
+           "genogrove removal lands";
 
+    size_t absorbed_in_tree = 0;
+    size_t live_in_tree = 0;
     for (const auto* seg : live) {
-        EXPECT_FALSE(seg->absorbed)
-            << "Tree traversal should not surface any absorbed segment";
+        if (seg->absorbed) ++absorbed_in_tree;
+        else               ++live_in_tree;
     }
+    EXPECT_EQ(absorbed_in_tree, 1u);
+    EXPECT_EQ(live_in_tree, 1u);
 }
 
 // ── Tier 1.3: Orphan EXON_TO_EXON edges are pruned by the sweep ────────────
 //
-// When reverse absorption tombstones a segment, the old EXON_TO_EXON edges
-// carrying that segment's segment_index become orphans (they link two exons
-// that are legitimately in the live parent chain, but with a dead id).
-// remove_tombstones calls remove_edges_if to strip them. Verify edge_count
-// drops compared to a no-sweep baseline built via the same files.
-TEST_F(BuilderPipelineTest, RemoveTombstones_OrphanEdgesPruned) {
+// Disabled until physical tombstone removal is re-enabled (blocked on
+// batch genogrove remove_key variant — see remove_tombstones() comment).
+// With the current counter-only sweep the swept and unswept edge counts
+// are identical, which this test would report as a failure.
+//
+// When the physical removal returns, rename back to
+// `RemoveTombstones_OrphanEdgesPruned` and re-enable.
+TEST_F(BuilderPipelineTest, DISABLED_RemoveTombstones_OrphanEdgesPruned) {
     auto ism_path = write_ism_gtf();
     auto parent_path = write_parent_gtf();
 


### PR DESCRIPTION
## Summary
- Replace the O(N × E) physical tombstone sweep in `builder::remove_tombstones` with a count-only default path that unblocks builds stuck after *Grove construction complete* (root cause: `graph_overlay::remove_edges_to` is O(E) per call, even though segments are never edge targets, so every `grove.remove_key()` paid the full adjacency-scan cost and the total was `N × E`).
- Add a new `--prune-tombstones` CLI option (off by default) that opts into the old physical-removal path for users who want a smaller distributable `.ggx` and can afford the slow post-build sweep.
- Consolidate the tombstone log into the existing *Grove construction complete* line: `… 529659 segments (2376 tombstones)` or `… (2376 tombstones pruned)`; the parenthetical is suppressed entirely when there are no absorptions.

### What changes by default
The tombstoned segment keys stay physically in the B+ tree. Every grove consumer (`analysis_report`, `export_gtf`, `transcript_matcher`, `splicing_catalog`, `build_bam`, `index_stats`) already has a defensive `if (seg.absorbed) continue;` filter, so this is correctness-safe — the trade-off is a slightly larger `.ggx` on disk and a bit of memory overhead in the grove. The build-summary counters (`total_segments`, `absorbed_segments`) still subtract tombstones so the summary output is unchanged.

### When to use `--prune-tombstones`
When you want to distribute a clean canonical index:

    atroplex build -m manifest.tsv --prune-tombstones

Expect minutes-to-hours on realistic cohorts (the sweep is still O(N × E) internally). Once genogrove exposes a batch `remove_key` variant that skips the incoming-edge scan for edge-source-only keys, the slow path can be retired and the flag made the default again.

### Tests
- `RemoveTombstones_PhysicallyRemoved` → `RemoveTombstones_DefaultKeepsInTree`: asserts the default leaves the tombstoned key in the tree, counter still populated, caches pruned, summary subtraction correct.
- New `RemoveTombstones_PruneFlagPhysicallyRemoves`: asserts `--prune-tombstones` removes the tombstoned segment from the B+ tree.
- Re-enabled `RemoveTombstones_PruneFlagDropsOrphanEdges` (was `DISABLED_`): asserts pruned grove has fewer edges than default by comparing `grove.edge_count()` across two builds.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] Project builds successfully in CLion
- [x] `atroplex build` on a real manifest clears *Grove construction complete* promptly (no multi-minute hang)
- [x] *Grove construction complete* log shows `(N tombstones)` for default and `(N tombstones pruned)` when `--prune-tombstones` is set
- [x] All `builder_pipeline_tests` pass (including the re-enabled `PruneFlagDropsOrphanEdges` variant)
- [x] `--prune-tombstones` produces a smaller `.ggx` than the default build on the same input