### PR TITLE
Trim build/load logs: drop per-chromosome noise, fix leading space

### DIFF
--- a/src/analysis_report.cpp
+++ b/src/analysis_report.cpp
@@ -90,8 +90,6 @@ void analysis_report::collect(grove_type& grove) {
         if (!root) continue;
         active_genes.clear();
 
-        logging::info("  " + seqid);
-
         auto* node = root;
         while (!node->get_is_leaf()) {
             auto& children = node->get_children();

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -197,20 +197,13 @@ build_summary builder::build_from_samples(grove_type& grove,
     build_summary stats;
     stats.collect(grove, segment_caches, exon_caches, segment_count, counters);
 
-    // Log per-chromosome summary
-    std::vector<std::string> seqids;
-    for (const auto& [seqid, _] : segment_caches) {
-        seqids.push_back(seqid);
-    }
-    std::sort(seqids.begin(), seqids.end(), chromosome_compare);
-
-    logging::info("Per-chromosome summary:");
-    for (const auto& seqid : seqids) {
-        auto& cs = stats.per_chromosome[seqid];
-        logging::info("  " + seqid + ": " +
-            std::to_string(cs.exons) + " exons, " +
-            std::to_string(cs.segments) + " segments");
-    }
+    // Concise one-line registry summary (detailed per-chromosome breakdown
+    // still lives on stats.per_chromosome and surfaces in the .ggx.summary).
+    logging::info("Chromosomes: " + std::to_string(stats.per_chromosome.size()) +
+                  ", Genes: " + std::to_string(stats.total_genes) +
+                  ", Sources: " + std::to_string(source_registry::instance().size()) +
+                  ", Transcripts: " + std::to_string(stats.total_transcripts) +
+                  ", Samples: " + std::to_string(sample_registry::instance().size()));
 
     // Move caches to caller if requested
     if (out_exon_caches) {

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -206,7 +206,8 @@ void subcall::load_grove(const std::string& path) {
     grove = std::make_unique<grove_type>(grove_type::deserialize(ifs));
 
     logging::info("Loaded index from: " + path);
-    logging::info("  Genes: " + std::to_string(gene_registry::instance().size()) +
+    logging::info("Chromosomes: " + std::to_string(grove->get_root_nodes().size()) +
+                  ", Genes: " + std::to_string(gene_registry::instance().size()) +
                   ", Sources: " + std::to_string(source_registry::instance().size()) +
                   ", Transcripts: " + std::to_string(transcript_registry::instance().size()) +
                   ", Samples: " + std::to_string(sample_registry::instance().size()));


### PR DESCRIPTION
## Summary
- Drop the leading two-space indent on the registry summary line emitted by `load_grove`.
- Replace the verbose "Per-chromosome summary:" block in `builder::build_from_samples` (one line per chromosome with exon + segment counts) with the same concise one-line format as `load_grove`, and add a `Chromosomes: N` field so both paths print the same summary. Detailed per-chromosome counts still live on `build_summary::per_chromosome` and surface in `.ggx.summary` for anyone who wants the breakdown.
- Drop the per-seqid progress line (`logging::info("  " + seqid)`) in `analysis_report::collect()` that fired once per chromosome during traversal — redundant with the summary line and noisy on whole-genome runs.

### New output

**Build:**
```
Grove construction complete: 529659 segments (2376 tombstones)
Chromosomes: 25, Genes: 113953, Sources: 4, Transcripts: 586931, Samples: 2
```

**Load:**
```
Loaded index from: /path/to/index.ggx
Chromosomes: 25, Genes: 113953, Sources: 4, Transcripts: 586931, Samples: 2
```

**Analyze:** no more `  chr1`, `  chr2`, … spam during traversal.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] Project builds successfully in CLion
- [x] `atroplex build -m manifest.tsv` prints the concise one-line summary after "Grove construction complete" and no per-chromosome block
- [x] `atroplex analyze --genogrove index.ggx` prints the one-line load summary with no leading space and no per-seqid log lines during traversal
- [x] `builder_pipeline_tests` still pass (no test references the removed log lines)
