### PR TITLE
Add --min-replicate-fraction for proportional thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`--min-replicate-fraction` flag** (#46, fixes #45): fraction-based replicate threshold (0-1). Effective threshold per group = `max(--min-replicates, ceil(fraction × group_size))`, capped at group_size. Both flags can be combined — stricter wins per group. Segments with zero sample attribution after merging (failed threshold in all groups, not in annotation) are excluded from build summary and inspect overview counts.
+
 - **`--annotated-loci-only` build filter** (#43): drops sample transcripts that don't spatially overlap any annotation segment on the same strand. Novel isoforms at annotated loci inherit the annotation's `gene_idx`, so sample-specific gene_ids (MSTRG.*, ENCLB*) no longer inflate the gene count. Annotation transcripts always pass. Expected to reduce gene count from ~1.15M to ~50-80K on mixed-source builds. Also: Docker CI now pushes PR images tagged `pr-<N>` for HPC testing; build log shows per-file segment delta; overview renames `transcripts` to `source_transcript_ids`.
 
 ### Changed

--- a/include/builder.hpp
+++ b/include/builder.hpp
@@ -56,6 +56,7 @@ public:
         const expression_filters& filters,
         bool absorb,
         int min_replicates,
+        double min_replicate_fraction,
         size_t fuzzy_tolerance,
         bool prune_tombstones,
         bool include_scaffolds = false,
@@ -91,7 +92,8 @@ private:
     static size_t merge_replicates(
         chromosome_exon_caches& exon_caches,
         chromosome_segment_caches& segment_caches,
-        int min_replicates
+        int min_replicates,
+        double min_replicate_fraction
     );
 
     /// Handle absorbed (tombstoned) segments after the build.

--- a/src/analysis_report.cpp
+++ b/src/analysis_report.cpp
@@ -490,11 +490,10 @@ void analysis_report::collect(grove_type& grove,
                 if (!is_segment(feature)) continue;
 
                 auto& seg = get_segment(feature);
-                // Skip tombstones. By default they stay in the tree
-                // (builder::remove_tombstones only counts + prunes caches);
-                // only `--prune-tombstones` physically removes them. Either
-                // way this filter keeps analysis_report correct.
+                // Skip tombstones and zero-attribution segments (features
+                // that lost all sample bits after replicate merging).
                 if (seg.absorbed) continue;
+                if (seg.sample_count() == 0) continue;
 
                 // ── Segment → per-sample ────────────────────────────
                 size_t seg_sample_count = seg.sample_count();

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -247,9 +247,18 @@ build_summary builder::build_from_samples(grove_type& grove,
         grove, segment_caches, prune_tombstones,
         &tombstoned_seg_indices, &tombstone_remap);
 
-    // Live segments = total minus tombstones that were reverse-absorbed.
-    size_t live_segments = (segment_count >= counters.absorbed_segments)
-        ? segment_count - counters.absorbed_segments
+    // Live segments = total minus tombstones minus zero-attribution segments
+    // (features that lost all sample bits after replicate merging).
+    size_t zero_attribution = 0;
+    for (const auto& [seqid, seg_cache] : segment_caches) {
+        for (const auto& [key, seg_ptr] : seg_cache) {
+            if (!is_segment(seg_ptr->get_data())) continue;
+            auto& seg = get_segment(seg_ptr->get_data());
+            if (!seg.absorbed && seg.sample_count() == 0) zero_attribution++;
+        }
+    }
+    size_t live_segments = (segment_count >= counters.absorbed_segments + zero_attribution)
+        ? segment_count - counters.absorbed_segments - zero_attribution
         : segment_count;
     std::string tombstone_note;
     if (counters.absorbed_segments > 0) {

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -578,5 +578,5 @@ build_summary builder::build_from_files(grove_type& grove,
         samples.push_back(std::move(info));
     }
 
-    return build_from_samples(grove, samples, threads, expression_filters{}, true, 0, 5, false, false, /*qtx_path=*/"", out_exon_caches);
+    return build_from_samples(grove, samples, threads, expression_filters{}, true, 0, 0.0, 5, false, false, /*qtx_path=*/"", out_exon_caches);
 }

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -11,6 +11,7 @@
 // standard
 #include <algorithm>
 #include <charconv>
+#include <cmath>
 #include <filesystem>
 #include <memory>
 #include <string_view>
@@ -54,6 +55,7 @@ build_summary builder::build_from_samples(grove_type& grove,
                                   const expression_filters& filters,
                                   bool absorb,
                                   int min_replicates,
+                                  double min_replicate_fraction,
                                   size_t fuzzy_tolerance,
                                   bool prune_tombstones,
                                   bool include_scaffolds,
@@ -227,8 +229,9 @@ build_summary builder::build_from_samples(grove_type& grove,
     }
 
     // --- Post-build replicate merging ---
-    if (min_replicates > 0) {
-        counters.replicates_merged = merge_replicates(exon_caches, segment_caches, min_replicates);
+    if (min_replicates > 0 || min_replicate_fraction > 0) {
+        counters.replicates_merged = merge_replicates(exon_caches, segment_caches,
+                                                       min_replicates, min_replicate_fraction);
     }
 
     // --- Count (and optionally physically remove) absorbed segments ---
@@ -349,7 +352,8 @@ build_summary builder::build_from_samples(grove_type& grove,
 size_t builder::merge_replicates(
     chromosome_exon_caches& exon_caches,
     chromosome_segment_caches& segment_caches,
-    int min_replicates
+    int min_replicates,
+    double min_replicate_fraction
 ) {
     // NOTE on interaction with the quantification sidecar (.qtx):
     // Replicate merging ORs the per-replicate sample_idx bits into the
@@ -415,9 +419,15 @@ size_t builder::merge_replicates(
                     }
                 }
 
-                // Cap threshold at group size (singletons always pass)
+                // Effective threshold = max(absolute, fraction-derived),
+                // capped at group size so singletons always survive.
+                size_t abs_threshold = (min_replicates > 0)
+                    ? static_cast<size_t>(min_replicates) : 0;
+                size_t frac_threshold = (min_replicate_fraction > 0)
+                    ? static_cast<size_t>(std::ceil(min_replicate_fraction
+                        * static_cast<double>(replicate_ids.size()))) : 0;
                 size_t threshold = std::min(
-                    static_cast<size_t>(min_replicates),
+                    std::max(abs_threshold, frac_threshold),
                     replicate_ids.size());
 
                 uint32_t merged_id = group_merged_ids.at(group_name);

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -56,6 +56,10 @@ void subcall::add_common_options(cxxopts::Options& options) {
             cxxopts::value<size_t>()->default_value("5"))
         ("min-replicates", "Merge biological replicates within groups; require features in >= N replicates (0 = no merge)",
             cxxopts::value<int>()->default_value("0"))
+        ("min-replicate-fraction", "Fraction-based replicate threshold (0-1). Feature must be in >= this fraction of replicates "
+            "in each group. Applied as max(--min-replicates, ceil(fraction * group_size)) per group, "
+            "so both flags can be set together (stricter wins). 0 = disabled.",
+            cxxopts::value<double>()->default_value("0"))
         ("prune-tombstones", "Physically remove absorbed (tombstoned) segments from the grove after build. "
             "Produces a smaller/cleaner .ggx at the cost of a slow post-build sweep "
             "(grove.remove_key is O(E) per call today). Default: off — tombstones stay in the tree and are filtered at query time.")
@@ -210,6 +214,7 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         bool absorb = !args.count("no-absorb");
         size_t fuzzy_tol = args["fuzzy-tolerance"].as<size_t>();
         int min_reps = args["min-replicates"].as<int>();
+        double min_rep_frac = args["min-replicate-fraction"].as<double>();
         bool prune_tombstones = args.count("prune-tombstones") > 0;
         logging::info("Creating grove with order: " + std::to_string(order));
 
@@ -251,8 +256,11 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         } else if (fuzzy_tol > 0) {
             logging::info("Fuzzy absorption tolerance: " + std::to_string(fuzzy_tol) + "bp");
         }
-        if (min_reps > 0) {
-            logging::info("Replicate merging enabled: min_replicates = " + std::to_string(min_reps));
+        if (min_reps > 0 || min_rep_frac > 0) {
+            std::string msg = "Replicate merging enabled:";
+            if (min_reps > 0) msg += " min_replicates=" + std::to_string(min_reps);
+            if (min_rep_frac > 0) msg += " min_replicate_fraction=" + std::to_string(min_rep_frac);
+            logging::info(msg);
         }
         if (prune_tombstones) {
             logging::info("Physical tombstone removal enabled (--prune-tombstones)");
@@ -289,7 +297,7 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         if (annotated_only) {
             logging::info("Annotated-loci-only mode: sample transcripts at novel loci will be discarded");
         }
-        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, min_reps, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only);
+        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, min_reps, min_rep_frac, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only);
         auto build_elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - build_start).count();
         build_stats->build_time_seconds = build_elapsed;
         logging::info("Grove ready with spatial index and graph structure");

--- a/tests/build/builder_pipeline_test.cpp
+++ b/tests/build/builder_pipeline_test.cpp
@@ -150,7 +150,7 @@ TEST_F(BuilderPipelineTest, BuilderFullPipeline_CountersPopulated) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/false);
 
     // 2 transcripts read from the two files
@@ -198,7 +198,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_DefaultKeepsInTree) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/false);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u)
@@ -241,7 +241,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagPhysicallyRemoves) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/true);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u);
@@ -279,7 +279,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
         auto summary = builder::build_from_samples(
             grove, samples,
             /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-            /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+            /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
             /*prune_tombstones=*/true);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
         pruned_edge_count = grove.edge_count();
@@ -303,7 +303,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
         auto summary = builder::build_from_samples(
             grove, samples,
             /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-            /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+            /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
             /*prune_tombstones=*/false);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
         default_edge_count = grove.edge_count();
@@ -334,7 +334,7 @@ TEST_F(BuilderPipelineTest, BuildSummary_WrittenFileContainsCounters) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*fuzzy_tolerance=*/5,
+        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/false);
 
     fs::path summary_path = tmp_dir / "test.ggx.summary";


### PR DESCRIPTION
## Summary
- New `--min-replicate-fraction` CLI flag (0-1). Feature must be present in >= this fraction of replicates within each group to survive merging. Adapts naturally to varying group sizes (e.g., 0.5 → 50% of replicates required regardless of group size).
- Effective threshold per group = `max(--min-replicates, ceil(fraction × group_size))`, capped at group_size. Both flags can be combined — stricter wins per group. Either flag alone triggers replicate merging.
- Examples at `--min-replicate-fraction 0.5`: group with 2 reps → need 1, group with 3 → need 2, group with 10 → need 5. Consistent 50% stringency vs the old absolute threshold giving 100%/67%/20%.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] All existing tests pass (default fraction=0 preserves current behavior)
- [x] `--min-replicates 2` alone behaves identically to before (no regression)
- [x] `--min-replicate-fraction 0.5` with a 3-replicate group requires features in >= 2 of 3
- [x] Both flags combined applies the stricter threshold per group