### PR TITLE
Remove build-time replicate merging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **Build-time replicate merging** (#47): `--min-replicates` and `--min-replicate-fraction` removed from the build path. The `merge_replicates()` function destructively cleared individual sample bits and replaced them with group bits, losing per-sample information needed for within-group analysis (e.g., boxplots). It also didn't save memory (bitset size unchanged) or remove dead segments. Sample/replicate filtering will move to inspect time (`--min-samples`, future PR) where it's non-destructive and reusable across different thresholds without rebuilding.
+
 ### Added
-- **`--min-replicate-fraction` flag** (#46, fixes #45): fraction-based replicate threshold (0-1). Effective threshold per group = `max(--min-replicates, ceil(fraction × group_size))`, capped at group_size. Both flags can be combined — stricter wins per group. Segments with zero sample attribution after merging (failed threshold in all groups, not in annotation) are excluded from build summary and inspect overview counts.
 
 - **`--annotated-loci-only` build filter** (#43): drops sample transcripts that don't spatially overlap any annotation segment on the same strand. Novel isoforms at annotated loci inherit the annotation's `gene_idx`, so sample-specific gene_ids (MSTRG.*, ENCLB*) no longer inflate the gene count. Annotation transcripts always pass. Docker CI now pushes PR images tagged `pr-<N>` for HPC testing; build log shows per-file segment delta; overview renames `transcripts` to `source_transcript_ids`.
 

--- a/include/build_summary.hpp
+++ b/include/build_summary.hpp
@@ -38,7 +38,6 @@
  *   discarded_transcripts — transcripts dropped entirely (expression filter,
  *                        mono-exon Rules 6/8, Rules 3/4 fragment drops against
  *                        reference parents)
- *   replicates_merged  — replicate entries collapsed by --min-replicates
  *   scaffold_filtered_transcripts — transcripts skipped at ingest because
  *                        their seqid is not a canonical main chromosome
  *                        (chr1..chr22, chrX, chrY, chrM). Disabled with
@@ -50,7 +49,6 @@ struct build_counters {
     size_t merged_transcripts = 0;
     size_t absorbed_segments = 0;
     size_t discarded_transcripts = 0;
-    size_t replicates_merged = 0;
     size_t scaffold_filtered_transcripts = 0;
 };
 

--- a/include/builder.hpp
+++ b/include/builder.hpp
@@ -55,8 +55,6 @@ public:
         uint32_t threads,
         const expression_filters& filters,
         bool absorb,
-        int min_replicates,
-        double min_replicate_fraction,
         size_t fuzzy_tolerance,
         bool prune_tombstones,
         bool include_scaffolds = false,
@@ -86,16 +84,6 @@ public:
     // static void add_fusion_segments(grove_type& grove, const fusion_data& fusions);
 
 private:
-    /// Post-build merge of biological replicates within groups.
-    /// Iterates exon and segment caches (no grove traversal).
-    /// Returns the number of replicate entries collapsed into merged groups.
-    static size_t merge_replicates(
-        chromosome_exon_caches& exon_caches,
-        chromosome_segment_caches& segment_caches,
-        int min_replicates,
-        double min_replicate_fraction
-    );
-
     /// Handle absorbed (tombstoned) segments after the build.
     /// Always counts tombstones, prunes them from segment_caches and
     /// gene_indices, and returns the count.

--- a/include/utility.hpp
+++ b/include/utility.hpp
@@ -51,9 +51,6 @@ namespace logging {
     void warning(const std::string& message);
     void error(const std::string& message);
 
-    void set_segment_qualifier(const std::string& q);
-    const std::string& segment_qualifier();
-
     /**
      * Enable or disable progress output (carriage return updates)
      * Progress is disabled by default for compatibility with non-interactive

--- a/src/analysis_report.cpp
+++ b/src/analysis_report.cpp
@@ -490,10 +490,7 @@ void analysis_report::collect(grove_type& grove,
                 if (!is_segment(feature)) continue;
 
                 auto& seg = get_segment(feature);
-                // Skip tombstones and zero-attribution segments (features
-                // that lost all sample bits after replicate merging).
                 if (seg.absorbed) continue;
-                if (seg.sample_count() == 0) continue;
 
                 // ── Segment → per-sample ────────────────────────────
                 size_t seg_sample_count = seg.sample_count();

--- a/src/build_summary.cpp
+++ b/src/build_summary.cpp
@@ -94,7 +94,7 @@ void build_summary::collect(
             if (!is_segment(feature)) continue;
 
             auto& seg = get_segment(feature);
-            if (seg.absorbed || seg.sample_count() == 0) continue;
+            if (seg.absorbed) continue;
             live_in_chrom++;
             auto& gi = genes[seg.gene_id()];
             gi.biotype = seg.gene_biotype();
@@ -250,9 +250,6 @@ void build_summary::write_summary(const std::string& path) const {
         << "  (segments tombstoned by reverse absorption and removed)\n";
     out << "  Discarded:        " << counters.discarded_transcripts
         << "  (expression filter, mono-exon, fragment drops)\n";
-    if (counters.replicates_merged > 0) {
-        out << "  Replicates merged: " << counters.replicates_merged << "\n";
-    }
     out << "\n";
 
     // Transcripts per gene

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -11,7 +11,6 @@
 // standard
 #include <algorithm>
 #include <charconv>
-#include <cmath>
 #include <filesystem>
 #include <memory>
 #include <string_view>
@@ -54,8 +53,6 @@ build_summary builder::build_from_samples(grove_type& grove,
                                   uint32_t threads,
                                   const expression_filters& filters,
                                   bool absorb,
-                                  int min_replicates,
-                                  double min_replicate_fraction,
                                   size_t fuzzy_tolerance,
                                   bool prune_tombstones,
                                   bool include_scaffolds,
@@ -82,7 +79,7 @@ build_summary builder::build_from_samples(grove_type& grove,
     //
     // The final single-file output is written at `qtx_path`; per-sample
     // temp streams go in `{qtx_path}.streams/` and are K-way merged into
-    // the final file after the main build + tombstone + replicate phases
+    // the final file after the main build + tombstone phases
     // complete. The streams directory is deleted on successful merge;
     // kept for debugging on failure. (`.tmp` suffix is reserved for
     // merge_to_qtx's own atomic-rename scratch file.)
@@ -133,10 +130,6 @@ build_summary builder::build_from_samples(grove_type& grove,
     chromosome_exon_caches exon_caches;
     chromosome_segment_caches segment_caches;
     size_t segment_count = 0;
-
-    if (min_replicates > 0 || min_replicate_fraction > 0) {
-        logging::set_segment_qualifier(" (pre-filter)");
-    }
 
     // Process each sample sequentially (annotations first)
     size_t total = ordered.size();
@@ -232,12 +225,6 @@ build_summary builder::build_from_samples(grove_type& grove,
         current_sample_meta.reset();
     }
 
-    // --- Post-build replicate merging ---
-    if (min_replicates > 0 || min_replicate_fraction > 0) {
-        counters.replicates_merged = merge_replicates(exon_caches, segment_caches,
-                                                       min_replicates, min_replicate_fraction);
-    }
-
     // --- Count (and optionally physically remove) absorbed segments ---
     // Collect the tombstoned segment_index values so the sidecar merge
     // below can skip emitting dead records for them in the final .qtx.
@@ -251,36 +238,16 @@ build_summary builder::build_from_samples(grove_type& grove,
         grove, segment_caches, prune_tombstones,
         &tombstoned_seg_indices, &tombstone_remap);
 
-    // Live segments = total minus tombstones minus zero-attribution segments
-    // (features that lost all sample bits after replicate merging).
-    size_t zero_attribution = 0;
-    for (const auto& [seqid, seg_cache] : segment_caches) {
-        for (const auto& [key, seg_ptr] : seg_cache) {
-            if (!is_segment(seg_ptr->get_data())) continue;
-            auto& seg = get_segment(seg_ptr->get_data());
-            if (!seg.absorbed && seg.sample_count() == 0) zero_attribution++;
-        }
-    }
-    size_t live_segments = (segment_count >= counters.absorbed_segments + zero_attribution)
-        ? segment_count - counters.absorbed_segments - zero_attribution
+    size_t live_segments = (segment_count >= counters.absorbed_segments)
+        ? segment_count - counters.absorbed_segments
         : segment_count;
     std::string tombstone_note;
     if (counters.absorbed_segments > 0) {
         tombstone_note = " (" + std::to_string(counters.absorbed_segments)
             + (prune_tombstones ? " tombstones pruned)" : " tombstones)");
     }
-    if (zero_attribution > 0) {
-        size_t pre_filter = segment_count - counters.absorbed_segments;
-        logging::info("Grove construction complete: " +
-            std::to_string(pre_filter) + " segments (pre-filter)" + tombstone_note);
-        logging::info("Replicate filtering: " + std::to_string(live_segments) +
-            " segments (post-filter, -" + std::to_string(zero_attribution) +
-            " below threshold)");
-        logging::set_segment_qualifier("");
-    } else {
-        logging::info("Grove construction complete: " + std::to_string(live_segments)
-            + " segments" + tombstone_note);
-    }
+    logging::info("Grove construction complete: " + std::to_string(live_segments)
+        + " segments" + tombstone_note);
 
     // End-of-build memory estimate — walks segment_caches / exon_caches /
     // gene_indices once and sums struct-owned heap allocations. Approximate
@@ -321,9 +288,9 @@ build_summary builder::build_from_samples(grove_type& grove,
     }
 
     // --- Phase: finalize quantification sidecar (K-way merge) ---
-    // Happens after remove_tombstones + merge_replicates so that any
-    // future logic that rewrites the sidecar in response to those
-    // phases can hook in here. The merge itself simply consumes the
+    // Happens after remove_tombstones so that any future logic that
+    // rewrites the sidecar in response to that phase can hook in
+    // here. The merge itself simply consumes the
     // per-sample temp streams produced during the build loop above.
     if (sidecar_enabled && !sidecar_stream_paths.empty()) {
         try {
@@ -356,10 +323,6 @@ build_summary builder::build_from_samples(grove_type& grove,
     // --- Collect summary statistics ---
     build_summary stats;
     stats.collect(grove, segment_caches, exon_caches, segment_count, counters);
-    if (zero_attribution > 0) {
-        stats.total_segments = (stats.total_segments >= zero_attribution)
-            ? stats.total_segments - zero_attribution : stats.total_segments;
-    }
 
     // Concise one-line registry summary (detailed per-chromosome breakdown
     // still lives on stats.per_chromosome and surfaces in the .ggx.summary).
@@ -374,132 +337,6 @@ build_summary builder::build_from_samples(grove_type& grove,
     }
 
     return stats;
-}
-
-size_t builder::merge_replicates(
-    chromosome_exon_caches& exon_caches,
-    chromosome_segment_caches& segment_caches,
-    int min_replicates,
-    double min_replicate_fraction
-) {
-    // NOTE on interaction with the quantification sidecar (.qtx):
-    // Replicate merging ORs the per-replicate sample_idx bits into the
-    // group's merged sample_id on each feature. The sidecar, however, was
-    // written out during the per-sample build phase and only contains
-    // records keyed by the ORIGINAL per-replicate sample_ids — the merged
-    // group_id is a "phantom" in the sidecar. At query time, code that
-    // wants quantitative aggregation across a replicate group has to
-    // either (a) expand the group's sample_id back to the constituent
-    // replicate IDs via sample_registry::group lookup and union their
-    // sidecar records, or (b) report per-replicate without collapsing.
-    // The current 3a PR defers this decision to the follow-up PR that
-    // wires quant_sidecar::Reader into query/inspect.
-    auto& registry = sample_registry::instance();
-
-    // Step 1: Build group -> replicate ID mapping
-    std::map<std::string, std::vector<uint32_t>> groups;
-    for (size_t i = 0; i < registry.size(); ++i) {
-        uint32_t rid = static_cast<uint32_t>(i);
-        const auto& info = registry.get(rid);
-        if (info.type != "sample" || info.group.empty()) continue;
-        groups[info.group].push_back(rid);
-    }
-
-    if (groups.empty()) {
-        logging::warning("No replicate groups found; skipping merge");
-        return 0;
-    }
-
-    // Step 2: Register merged sample_info for each group
-    std::map<std::string, uint32_t> group_merged_ids;
-    for (auto& [group_name, replicate_ids] : groups) {
-        const auto& first = registry.get(replicate_ids[0]);
-        sample_info merged(first);
-        merged.id = group_name;
-        merged.group = group_name;
-        merged.description = "Merged from " + std::to_string(replicate_ids.size()) + " replicates";
-        merged.source_file.clear();
-
-        uint32_t merged_id = registry.register_data(std::move(merged));
-        group_merged_ids[group_name] = merged_id;
-
-        if (replicate_ids.size() == 1 && min_replicates > 1) {
-            logging::warning("Group '" + group_name + "' has only 1 replicate "
-                "but min_replicates=" + std::to_string(min_replicates) +
-                "; threshold capped to 1");
-        }
-
-        logging::info("Replicate group '" + group_name + "': " +
-            std::to_string(replicate_ids.size()) + " replicates");
-    }
-
-    // Step 3: Walk caches and merge bits/expression
-    // Lambda that works on both exon_feature and segment_feature via std::visit
-    auto merge_feature = [&](genomic_feature& feature) {
-        std::visit([&](auto& f) {
-            for (const auto& [group_name, replicate_ids] : groups) {
-                size_t rep_count = 0;
-
-                for (uint32_t rid : replicate_ids) {
-                    if (f.sample_idx.test(rid)) {
-                        rep_count++;
-                    }
-                }
-
-                // Effective threshold = max(absolute, fraction-derived),
-                // capped at group size so singletons always survive.
-                size_t abs_threshold = (min_replicates > 0)
-                    ? static_cast<size_t>(min_replicates) : 0;
-                size_t frac_threshold = (min_replicate_fraction > 0)
-                    ? static_cast<size_t>(std::ceil(min_replicate_fraction
-                        * static_cast<double>(replicate_ids.size()))) : 0;
-                size_t threshold = std::min(
-                    std::max(abs_threshold, frac_threshold),
-                    replicate_ids.size());
-
-                uint32_t merged_id = group_merged_ids.at(group_name);
-                if (rep_count >= threshold) {
-                    f.add_sample(merged_id);
-                }
-
-                // Clear replicate bits
-                for (uint32_t rid : replicate_ids) {
-                    f.sample_idx.clear(rid);
-                }
-            }
-        }, feature);
-    };
-
-    // Walk exon caches
-    for (auto& [seqid, exon_cache] : exon_caches) {
-        for (auto& [coord, exon_ptr] : exon_cache) {
-            merge_feature(exon_ptr->get_data());
-        }
-    }
-
-    // Walk segment caches
-    for (auto& [seqid, seg_cache] : segment_caches) {
-        for (auto& [key, seg_ptr] : seg_cache) {
-            auto& feature = seg_ptr->get_data();
-            if (!is_segment(feature)) continue;
-            if (get_segment(feature).absorbed) continue;
-            merge_feature(feature);
-        }
-    }
-
-    // Step 4: Mark replicate entries as type="replicate" so they're excluded from stats
-    size_t collapsed = 0;
-    for (const auto& [group_name, replicate_ids] : groups) {
-        for (uint32_t rid : replicate_ids) {
-            registry.get(rid).type = "replicate";
-            ++collapsed;
-        }
-    }
-
-    logging::info("Replicate merging complete: " +
-        std::to_string(group_merged_ids.size()) + " groups, min_replicates=" +
-        std::to_string(min_replicates));
-    return collapsed;
 }
 
 size_t builder::remove_tombstones(
@@ -605,5 +442,5 @@ build_summary builder::build_from_files(grove_type& grove,
         samples.push_back(std::move(info));
     }
 
-    return build_from_samples(grove, samples, threads, expression_filters{}, true, 0, 0.0, 5, false, false, /*qtx_path=*/"", out_exon_caches);
+    return build_from_samples(grove, samples, threads, expression_filters{}, true, 5, false, false, /*qtx_path=*/"", out_exon_caches);
 }

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -54,12 +54,6 @@ void subcall::add_common_options(cxxopts::Options& options) {
         ("no-absorb", "Disable ISM (Incomplete Splice Match) segment absorption into longer parents")
         ("fuzzy-tolerance", "Max bp difference for fuzzy exon boundary matching during absorption (0 = exact only)",
             cxxopts::value<size_t>()->default_value("5"))
-        ("min-replicates", "Merge biological replicates within groups; require features in >= N replicates (0 = no merge)",
-            cxxopts::value<int>()->default_value("0"))
-        ("min-replicate-fraction", "Fraction-based replicate threshold (0-1). Feature must be in >= this fraction of replicates "
-            "in each group. Applied as max(--min-replicates, ceil(fraction * group_size)) per group, "
-            "so both flags can be set together (stricter wins). 0 = disabled.",
-            cxxopts::value<double>()->default_value("0"))
         ("prune-tombstones", "Physically remove absorbed (tombstoned) segments from the grove after build. "
             "Produces a smaller/cleaner .ggx at the cost of a slow post-build sweep "
             "(grove.remove_key is O(E) per call today). Default: off — tombstones stay in the tree and are filtered at query time.")
@@ -213,8 +207,6 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
 
         bool absorb = !args.count("no-absorb");
         size_t fuzzy_tol = args["fuzzy-tolerance"].as<size_t>();
-        int min_reps = args["min-replicates"].as<int>();
-        double min_rep_frac = args["min-replicate-fraction"].as<double>();
         bool prune_tombstones = args.count("prune-tombstones") > 0;
         logging::info("Creating grove with order: " + std::to_string(order));
 
@@ -256,12 +248,6 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         } else if (fuzzy_tol > 0) {
             logging::info("Fuzzy absorption tolerance: " + std::to_string(fuzzy_tol) + "bp");
         }
-        if (min_reps > 0 || min_rep_frac > 0) {
-            std::string msg = "Replicate merging enabled:";
-            if (min_reps > 0) msg += " min_replicates=" + std::to_string(min_reps);
-            if (min_rep_frac > 0) msg += " min_replicate_fraction=" + std::to_string(min_rep_frac);
-            logging::info(msg);
-        }
         if (prune_tombstones) {
             logging::info("Physical tombstone removal enabled (--prune-tombstones)");
         }
@@ -297,7 +283,7 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         if (annotated_only) {
             logging::info("Annotated-loci-only mode: sample transcripts at novel loci will be discarded");
         }
-        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, min_reps, min_rep_frac, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only);
+        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only);
         auto build_elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - build_start).count();
         build_stats->build_time_seconds = build_elapsed;
         logging::info("Grove ready with spatial index and graph structure");

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -80,10 +80,6 @@ namespace logging {
     // Thread safety
     static std::mutex log_mutex;
 
-    static std::string seg_qualifier;
-    void set_segment_qualifier(const std::string& q) { seg_qualifier = q; }
-    const std::string& segment_qualifier() { return seg_qualifier; }
-
     // Progress tracking
     static std::chrono::steady_clock::time_point progress_start_time;
     static bool progress_enabled = false;  // Disabled by default (for SLURM, CI, etc.)
@@ -161,7 +157,6 @@ namespace logging {
         std::cout << "[atroplex] " << get_timestamp() << " - "
                   << prefix << " " << format_number(total_segments)
                   << " total segments (+" << format_number(new_segments) << ")"
-                  << seg_qualifier
                   << " in " << std::fixed << std::setprecision(1) << seconds << "s"
                   << (progress_enabled ? "                    " : "")
                   << std::endl;

--- a/tests/build/builder_pipeline_test.cpp
+++ b/tests/build/builder_pipeline_test.cpp
@@ -150,7 +150,7 @@ TEST_F(BuilderPipelineTest, BuilderFullPipeline_CountersPopulated) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
+        /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/false);
 
     // 2 transcripts read from the two files
@@ -166,9 +166,6 @@ TEST_F(BuilderPipelineTest, BuilderFullPipeline_CountersPopulated) {
 
     // No filter drops
     EXPECT_EQ(summary.counters.discarded_transcripts, 0u);
-
-    // No replicates configured
-    EXPECT_EQ(summary.counters.replicates_merged, 0u);
 
     // After sweep: only the parent segment remains
     EXPECT_EQ(summary.total_segments, 1u);
@@ -198,7 +195,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_DefaultKeepsInTree) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
+        /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/false);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u)
@@ -241,7 +238,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagPhysicallyRemoves) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
+        /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/true);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u);
@@ -279,7 +276,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
         auto summary = builder::build_from_samples(
             grove, samples,
             /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-            /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
+            /*fuzzy_tolerance=*/5,
             /*prune_tombstones=*/true);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
         pruned_edge_count = grove.edge_count();
@@ -303,7 +300,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
         auto summary = builder::build_from_samples(
             grove, samples,
             /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-            /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
+            /*fuzzy_tolerance=*/5,
             /*prune_tombstones=*/false);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
         default_edge_count = grove.edge_count();
@@ -334,7 +331,7 @@ TEST_F(BuilderPipelineTest, BuildSummary_WrittenFileContainsCounters) {
     auto summary = builder::build_from_samples(
         grove, samples,
         /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*min_replicates=*/0, /*min_replicate_fraction=*/0.0, /*fuzzy_tolerance=*/5,
+        /*fuzzy_tolerance=*/5,
         /*prune_tombstones=*/false);
 
     fs::path summary_path = tmp_dir / "test.ggx.summary";


### PR DESCRIPTION
## Summary
- Remove `--min-replicates` and `--min-replicate-fraction` from the build path entirely. The `merge_replicates()` function, group bit registration, and all parameter threading are deleted (-208 lines net).
- Replicate/sample filtering will move to inspect time (`--min-samples`, future PR) where it's non-destructive: the grove preserves all per-sample bits, and different filtering thresholds can be explored without rebuilding.
- Expression filters (`--min-counts`, `--min-TPM`, etc.) remain at build time — they prevent noisy transcripts from creating segments in the first place.
- The `group` field on `sample_info` is preserved for `query --contrast` DTU grouping.

**Rationale:** Build-time merging was destructive (cleared individual sample bits, replaced with group bits), didn't save memory (bitset size unchanged), didn't remove dead segments from the grove, and prevented per-sample analysis (boxplots, within-group variation). Moving filtering to inspect makes the grove a reusable build artifact.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] All existing tests pass
- [x] `atroplex build --help` no longer shows `--min-replicates` or `--min-replicate-fraction`
- [x] Build produces per-sample bits (not group bits) — `per_sample.tsv` from inspect shows individual samples, not merged groups