### PR TITLE
Add --min-samples to inspect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Removed
-- **Build-time replicate merging** (#47): `--min-replicates` and `--min-replicate-fraction` removed from the build path. The `merge_replicates()` function destructively cleared individual sample bits and replaced them with group bits, losing per-sample information needed for within-group analysis (e.g., boxplots). It also didn't save memory (bitset size unchanged) or remove dead segments. Sample/replicate filtering will move to inspect time (`--min-samples`, future PR) where it's non-destructive and reusable across different thresholds without rebuilding.
+- **Build-time replicate merging** (#47): `--min-replicates` and `--min-replicate-fraction` removed from the build path. The `merge_replicates()` function destructively cleared individual sample bits and replaced them with group bits, losing per-sample information needed for within-group analysis (e.g., boxplots). It also didn't save memory (bitset size unchanged) or remove dead segments. Replaced by inspect-time `--min-samples` (#48).
 
 ### Added
+- **`--min-samples` for inspect** (#48): non-destructive sample-count filter applied during the grove traversal. Segments present in fewer than N samples are skipped — all downstream outputs (overview, sharing, hubs, events) reflect the threshold. The grove is not modified, so different thresholds can be explored without rebuilding.
+
 
 - **`--annotated-loci-only` build filter** (#43): drops sample transcripts that don't spatially overlap any annotation segment on the same strand. Novel isoforms at annotated loci inherit the annotation's `gene_idx`, so sample-specific gene_ids (MSTRG.*, ENCLB*) no longer inflate the gene count. Annotation transcripts always pass. Docker CI now pushes PR images tagged `pr-<N>` for HPC testing; build log shows per-file segment delta; overview renames `transcripts` to `source_transcript_ids`.
 

--- a/include/analysis_report.hpp
+++ b/include/analysis_report.hpp
@@ -212,7 +212,8 @@ struct analysis_report {
      * inspect invocation.
      */
     void collect(grove_type& grove,
-                 quant_sidecar::Reader* qtx_reader = nullptr);
+                 quant_sidecar::Reader* qtx_reader = nullptr,
+                 size_t min_samples = 0);
 
     // ── Output ──────────────────────────────────────────────────────
 

--- a/src/analysis_report.cpp
+++ b/src/analysis_report.cpp
@@ -51,8 +51,12 @@ double compute_median(std::vector<size_t>& values) {
 } // anonymous namespace
 
 void analysis_report::collect(grove_type& grove,
-                              quant_sidecar::Reader* qtx_reader) {
+                              quant_sidecar::Reader* qtx_reader,
+                              size_t min_samples) {
     logging::info("Collecting analysis report...");
+    if (min_samples > 0) {
+        logging::info("Filtering: segments with < " + std::to_string(min_samples) + " samples excluded");
+    }
     if (qtx_reader) {
         logging::info("Quantitative columns enabled (reading from .qtx sidecar)");
     }
@@ -491,6 +495,7 @@ void analysis_report::collect(grove_type& grove,
 
                 auto& seg = get_segment(feature);
                 if (seg.absorbed) continue;
+                if (min_samples > 0 && seg.sample_count() < min_samples) continue;
 
                 // ── Segment → per-sample ────────────────────────────
                 size_t seg_sample_count = seg.sample_count();

--- a/src/subcall/inspect.cpp
+++ b/src/subcall/inspect.cpp
@@ -23,6 +23,12 @@ cxxopts::Options inspect::parse_args(int argc, char** argv) {
 
     add_common_options(options);
 
+    options.add_options("Filtering")
+        ("min-samples", "Only include segments present in >= N samples. "
+            "Applied non-destructively during traversal — the grove is not modified.",
+            cxxopts::value<size_t>()->default_value("0"))
+        ;
+
     return options;
 }
 
@@ -109,7 +115,8 @@ void inspect::execute(const cxxopts::ParseResult& args) {
     report.begin_splicing_events_stream(
         (events_dir / (basename + ".splicing_events.tsv")).string());
 
-    report.collect(*grove, qtx_reader_ptr());
+    size_t min_samples = args["min-samples"].as<size_t>();
+    report.collect(*grove, qtx_reader_ptr(), min_samples);
 
     report.write_overview((overview_dir / (basename + ".overview.tsv")).string());
     report.write_per_sample((overview_dir / (basename + ".per_sample.tsv")).string());


### PR DESCRIPTION
## Summary
- New `--min-samples N` flag on `atroplex inspect`. Segments present in fewer than N samples are skipped during the grove traversal. All downstream outputs (overview, sharing, hubs, events) only include segments that pass the filter.
- Non-destructive: the grove is not modified. Different thresholds can be explored without rebuilding — run inspect multiple times with different `--min-samples` values against the same `.ggx`.
- Replaces the removed build-time `--min-replicates` (PR #47) as the reproducibility filter, with the advantage that per-sample data is preserved in the grove for within-group analysis.

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] All existing tests pass (default min-samples=0 preserves current behavior)
- [x] `atroplex inspect --min-samples 2` excludes single-sample segments from all outputs
- [x] `atroplex inspect` without the flag produces identical output to before
- [x] Overview gene/segment counts decrease with increasing `--min-samples`