### PR TITLE
Record build parameters in .ggx.summary

### DIFF
--- a/include/build_summary.hpp
+++ b/include/build_summary.hpp
@@ -112,6 +112,9 @@ struct build_summary {
     // ── Build timing ──────────────────────────────────────────────
     double build_time_seconds = 0;
 
+    // ── Build parameters (for summary provenance) ────────────────
+    std::map<std::string, std::string> build_parameters;
+
     /**
      * Populate this build_summary from builder caches post-sweep.
      * Caller must have already run tombstone cleanup and replicate merging.

--- a/src/build_summary.cpp
+++ b/src/build_summary.cpp
@@ -184,6 +184,15 @@ void build_summary::write_summary(const std::string& path) const {
     out << "Index Summary\n";
     out << "=============\n\n";
 
+    // Build parameters
+    if (!build_parameters.empty()) {
+        out << "Build parameters:\n";
+        for (const auto& [key, value] : build_parameters) {
+            out << "  " << key << ": " << value << "\n";
+        }
+        out << "\n";
+    }
+
     // Build time
     if (build_time_seconds > 0) {
         if (build_time_seconds >= 60) {

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -286,6 +286,25 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only);
         auto build_elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - build_start).count();
         build_stats->build_time_seconds = build_elapsed;
+
+        // Record build parameters for summary provenance
+        build_stats->build_parameters["order"] = std::to_string(order);
+        build_stats->build_parameters["absorb"] = absorb ? "yes" : "no";
+        if (absorb && fuzzy_tol > 0)
+            build_stats->build_parameters["fuzzy_tolerance"] = std::to_string(fuzzy_tol) + "bp";
+        build_stats->build_parameters["include_scaffolds"] = include_scaffolds ? "yes" : "no";
+        build_stats->build_parameters["annotated_loci_only"] = annotated_only ? "yes" : "no";
+        if (filters.min_counts >= 0)
+            build_stats->build_parameters["min_counts"] = std::to_string(static_cast<int>(filters.min_counts));
+        if (filters.min_TPM >= 0)
+            build_stats->build_parameters["min_TPM"] = std::to_string(static_cast<int>(filters.min_TPM));
+        if (filters.min_FPKM >= 0)
+            build_stats->build_parameters["min_FPKM"] = std::to_string(static_cast<int>(filters.min_FPKM));
+        if (filters.min_RPKM >= 0)
+            build_stats->build_parameters["min_RPKM"] = std::to_string(static_cast<int>(filters.min_RPKM));
+        if (filters.min_cov >= 0)
+            build_stats->build_parameters["min_cov"] = std::to_string(static_cast<int>(filters.min_cov));
+
         logging::info("Grove ready with spatial index and graph structure");
 
         // Open the qtx reader we just produced so the subclass execute()


### PR DESCRIPTION
## Summary
- Add `build_parameters` map to `build_summary` struct
- Populate with order, absorb, fuzzy_tolerance, include_scaffolds, annotated_loci_only, and active expression filters after build
- Write as "Build parameters" section at top of `.ggx.summary` for provenance/reproducibility

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `.ggx.summary` shows build parameters section when built with non-default options
- [x] Parameters section omitted when map is empty (e.g. `--build-from` path)
- [x] All tests pass