### PR TITLE
Add --chromosomes build filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build-time replicate merging** (#47): `--min-replicates` and `--min-replicate-fraction` removed from the build path. The `merge_replicates()` function destructively cleared individual sample bits and replaced them with group bits, losing per-sample information needed for within-group analysis (e.g., boxplots). It also didn't save memory (bitset size unchanged) or remove dead segments. Replaced by inspect-time `--min-samples` (#48).
 
 ### Added
+- **`--chromosomes` build filter** (#50): restrict index building to specific chromosomes (e.g. `--chromosomes chr1,chr22,chrX`). Features on unlisted chromosomes are silently skipped at ingest. Accepts both prefixed (`chr1`) and bare (`1`) names. Recorded in `.ggx.summary` build parameters. Applied in both GFF and BAM build paths.
+- **Build parameters in `.ggx.summary`** (#49): the summary now records order, absorb, fuzzy_tolerance, scaffold/loci filters, expression thresholds, and chromosome filter for reproducibility.
 - **`--min-samples` for inspect** (#48): non-destructive sample-count filter applied during the grove traversal. Segments present in fewer than N samples are skipped — all downstream outputs (overview, sharing, hubs, events) reflect the threshold. The grove is not modified, so different thresholds can be explored without rebuilding.
 
 

--- a/include/build_bam.hpp
+++ b/include/build_bam.hpp
@@ -16,6 +16,7 @@
 #include <vector>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <filesystem>
 #include <mutex>
 
@@ -60,7 +61,8 @@ public:
                       bool include_scaffolds,
                       build_counters& counters,
                       quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr,
-                      bool annotated_loci_only = false);
+                      bool annotated_loci_only = false,
+                      const std::unordered_set<std::string>& chromosomes_filter = {});
 
     /**
      * Parse BAM header to extract sample metadata.

--- a/include/build_gff.hpp
+++ b/include/build_gff.hpp
@@ -17,6 +17,7 @@
 #include <vector>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 #include <filesystem>
 #include <mutex>
 
@@ -68,7 +69,8 @@ public:
                       bool include_scaffolds,
                       build_counters& counters,
                       quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr,
-                      bool annotated_loci_only = false);
+                      bool annotated_loci_only = false,
+                      const std::unordered_set<std::string>& chromosomes_filter = {});
 
     /**
      * Parse GTF/GFF header to extract sample metadata

--- a/include/builder.hpp
+++ b/include/builder.hpp
@@ -60,7 +60,8 @@ public:
         bool include_scaffolds = false,
         const std::string& qtx_path = "",
         chromosome_exon_caches* out_exon_caches = nullptr,
-        bool annotated_loci_only = false
+        bool annotated_loci_only = false,
+        const std::unordered_set<std::string>& chromosomes_filter = {}
     );
 
     /**

--- a/include/subcall/subcall.hpp
+++ b/include/subcall/subcall.hpp
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <unordered_set>
 
 #include <cxxopts.hpp>
 
@@ -78,6 +79,7 @@ protected:
     chromosome_exon_caches exon_caches_;
     std::filesystem::path output_dir;
     bool include_scaffolds = false;  // set from --include-scaffolds (default: main chromosomes only)
+    std::unordered_set<std::string> chromosomes_filter;  // set from --chromosomes
 
     /// Quantification sidecar reader, opened lazily by setup_grove when a
     /// `{prefix}.qtx` file is found alongside the loaded `.ggx`. Empty when

--- a/src/build_bam.cpp
+++ b/src/build_bam.cpp
@@ -30,7 +30,8 @@ void build_bam::build(grove_type& grove,
     bool include_scaffolds,
     build_counters& counters,
     quant_sidecar::SampleStreamWriter* sidecar_writer,
-    bool annotated_loci_only) {
+    bool annotated_loci_only,
+    const std::unordered_set<std::string>& chromosomes_filter) {
 
     const size_t segment_count_before = segment_count;
 
@@ -61,6 +62,11 @@ void build_bam::build(grove_type& grove,
         // bumping input_transcripts.
         if (!is_main_chromosome(cluster.seqid, include_scaffolds)) {
             counters.scaffold_filtered_transcripts++;
+            continue;
+        }
+
+        if (!chromosomes_filter.empty() &&
+            chromosomes_filter.find(normalize_chromosome(cluster.seqid)) == chromosomes_filter.end()) {
             continue;
         }
 

--- a/src/build_gff.cpp
+++ b/src/build_gff.cpp
@@ -35,7 +35,8 @@ void build_gff::build(grove_type& grove,
     bool include_scaffolds,
     build_counters& counters,
     quant_sidecar::SampleStreamWriter* sidecar_writer,
-    bool annotated_loci_only) {
+    bool annotated_loci_only,
+    const std::unordered_set<std::string>& chromosomes_filter) {
 
     gio::gff_reader reader(filepath.string());
     const size_t segment_count_before = segment_count;
@@ -68,6 +69,11 @@ void build_gff::build(grove_type& grove,
             if (entry.type == "transcript") {
                 counters.scaffold_filtered_transcripts++;
             }
+            continue;
+        }
+
+        if (!chromosomes_filter.empty() &&
+            chromosomes_filter.find(normalize_chromosome(entry.seqid)) == chromosomes_filter.end()) {
             continue;
         }
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -58,7 +58,8 @@ build_summary builder::build_from_samples(grove_type& grove,
                                   bool include_scaffolds,
                                   const std::string& qtx_path,
                                   chromosome_exon_caches* out_exon_caches,
-                                  bool annotated_loci_only) {
+                                  bool annotated_loci_only,
+                                  const std::unordered_set<std::string>& chromosomes_filter) {
     if (samples.empty()) {
         logging::warning("No samples provided to build genogrove");
         return {};
@@ -189,7 +190,7 @@ build_summary builder::build_from_samples(grove_type& grove,
             open_sidecar(registry_id);
 
             // Build with persistent caches for cross-file deduplication
-            build_gff::build(grove, filepath, registry_id, exon_caches, segment_caches, segment_count, threads, filters, absorb, fuzzy_tolerance, include_scaffolds, counters, sidecar.get(), annotated_loci_only);
+            build_gff::build(grove, filepath, registry_id, exon_caches, segment_caches, segment_count, threads, filters, absorb, fuzzy_tolerance, include_scaffolds, counters, sidecar.get(), annotated_loci_only, chromosomes_filter);
         } else if (ftype == gio::filetype::BAM || ftype == gio::filetype::SAM) {
             logging::info("[" + std::to_string(current) + "/" + std::to_string(total) + "] Processing BAM: " + filepath.filename().string() +
                          (info.id.empty() ? "" : " (id: " + info.id + ")"));
@@ -199,7 +200,7 @@ build_summary builder::build_from_samples(grove_type& grove,
 
             build_bam::build(grove, filepath, registry_id, exon_caches, segment_caches,
                             segment_count, filters, absorb, fuzzy_tolerance, include_scaffolds, counters, sidecar.get(),
-                            annotated_loci_only);
+                            annotated_loci_only, chromosomes_filter);
         } else {
             logging::warning("Unsupported file type for: " + filepath.string());
         }

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -12,6 +12,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 
 #include "utility.hpp"
 #include "builder.hpp"
@@ -66,6 +67,10 @@ void subcall::add_common_options(cxxopts::Options& options) {
             "segment in the grove. Novel intergenic and antisense gene loci (which are predominantly "
             "long-read artifacts) are discarded. Requires at least one annotation entry in the manifest. "
             "Default: off — all transcripts are indexed.")
+        ("chromosomes", "Restrict index to specific chromosomes (comma-separated, e.g. chr1,chr22,chrX). "
+            "Features on unlisted chromosomes are silently skipped at ingest. Accepts both prefixed "
+            "(chr1) and bare (1) names. Default: all chromosomes.",
+            cxxopts::value<std::string>())
         ;
 }
 
@@ -135,6 +140,19 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
     // Capture the scaffold-inclusion preference early so it's visible to
     // anything the subclass does during execute(), not just the build path.
     include_scaffolds = args.count("include-scaffolds") > 0;
+
+    if (args.count("chromosomes")) {
+        std::string chr_arg = args["chromosomes"].as<std::string>();
+        std::istringstream ss(chr_arg);
+        std::string token;
+        while (std::getline(ss, token, ',')) {
+            token.erase(0, token.find_first_not_of(' '));
+            token.erase(token.find_last_not_of(' ') + 1);
+            if (!token.empty()) {
+                chromosomes_filter.insert(normalize_chromosome(token));
+            }
+        }
+    }
 
     if (args.count("genogrove")) {
         std::filesystem::path grove_dir = args["genogrove"].as<std::string>();
@@ -256,6 +274,14 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         } else {
             logging::info("Scaffold filter active: main chromosomes only (chr1..chr22, chrX, chrY, chrM)");
         }
+        if (!chromosomes_filter.empty()) {
+            std::string chr_list;
+            for (const auto& c : chromosomes_filter) {
+                if (!chr_list.empty()) chr_list += ", ";
+                chr_list += c;
+            }
+            logging::info("Chromosome filter active: " + chr_list);
+        }
         grove = std::make_unique<grove_type>(order);
 
         // Derive the final single-file quantification sidecar path. We
@@ -283,7 +309,7 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
         if (annotated_only) {
             logging::info("Annotated-loci-only mode: sample transcripts at novel loci will be discarded");
         }
-        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only);
+        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only, chromosomes_filter);
         auto build_elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - build_start).count();
         build_stats->build_time_seconds = build_elapsed;
 
@@ -294,6 +320,14 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
             build_stats->build_parameters["fuzzy_tolerance"] = std::to_string(fuzzy_tol) + "bp";
         build_stats->build_parameters["include_scaffolds"] = include_scaffolds ? "yes" : "no";
         build_stats->build_parameters["annotated_loci_only"] = annotated_only ? "yes" : "no";
+        if (!chromosomes_filter.empty()) {
+            std::string chr_list;
+            for (const auto& c : chromosomes_filter) {
+                if (!chr_list.empty()) chr_list += ",";
+                chr_list += c;
+            }
+            build_stats->build_parameters["chromosomes"] = chr_list;
+        }
         if (filters.min_counts >= 0)
             build_stats->build_parameters["min_counts"] = std::to_string(static_cast<int>(filters.min_counts));
         if (filters.min_TPM >= 0)


### PR DESCRIPTION
## Summary
- Add `--chromosomes chr1,chr22,chrX` CLI option to restrict index building to specific chromosomes
- Filter applied at ingest (after scaffold filter) in both GFF and BAM build paths
- Accepts both prefixed (`chr1`) and bare (`1`) chromosome names via `normalize_chromosome()`
- Recorded in `.ggx.summary` build parameters for provenance

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] Building with `--chromosomes chr1` produces an index containing only chr1 features
- [x] Building without `--chromosomes` is unchanged (all chromosomes indexed)
- [x] All existing tests pass (new parameter has default `{}`)
- [x] Build parameters section in `.ggx.summary` lists the chromosome filter when used