### PR TITLE
Add per-leaf progress to inspect; update README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Build-time replicate merging** (#47): `--min-replicates` and `--min-replicate-fraction` removed from the build path. The `merge_replicates()` function destructively cleared individual sample bits and replaced them with group bits, losing per-sample information needed for within-group analysis (e.g., boxplots). It also didn't save memory (bitset size unchanged) or remove dead segments. Replaced by inspect-time `--min-samples` (#48).
 
 ### Added
-- **`--chromosomes` build filter** (#50): restrict index building to specific chromosomes (e.g. `--chromosomes chr1,chr22,chrX`). Features on unlisted chromosomes are silently skipped at ingest. Accepts both prefixed (`chr1`) and bare (`1`) names. Recorded in `.ggx.summary` build parameters. Applied in both GFF and BAM build paths.
-- **Build parameters in `.ggx.summary`** (#49): the summary now records order, absorb, fuzzy_tolerance, scaffold/loci filters, expression thresholds, and chromosome filter for reproducibility.
+- **Per-leaf progress for inspect** ([#51](https://github.com/ylab-hi/atroplex/pull/51)): `--progress` now shows per-chromosome leaf-node and segment counts during the grove traversal, so long-running inspections show visible progress.
+- **`--chromosomes` build filter** ([#50](https://github.com/ylab-hi/atroplex/pull/50)): restrict index building to specific chromosomes (e.g. `--chromosomes chr1,chr22,chrX`). Features on unlisted chromosomes are silently skipped at ingest. Accepts both prefixed (`chr1`) and bare (`1`) names. Recorded in `.ggx.summary` build parameters. Applied in both GFF and BAM build paths.
+- **Build parameters in `.ggx.summary`** ([#49](https://github.com/ylab-hi/atroplex/pull/49)): the summary now records order, absorb, fuzzy_tolerance, scaffold/loci filters, expression thresholds, and chromosome filter for reproducibility.
 - **`--min-samples` for inspect** (#48): non-destructive sample-count filter applied during the grove traversal. Segments present in fewer than N samples are skipped — all downstream outputs (overview, sharing, hubs, events) reflect the threshold. The grove is not modified, so different thresholds can be explored without rebuilding.
 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cmake --build build
 ### Dependencies
 
 - **cxxopts** (v3.3.1): Command-line argument parsing (fetched automatically)
-- **genogrove** (v0.20.2): Genomic interval data structures and graph structure (fetched automatically)
+- **genogrove** (v0.21.0): Genomic interval data structures and graph structure (fetched automatically)
 - **htslib**: Reading BAM/SAM files (system dependency via pkg-config)
 - **zlib**: Compression support
 
@@ -37,10 +37,13 @@ atroplex build -b annotation.gtf
 # Build pan-transcriptome from multiple sources via manifest
 atroplex build -m manifest.tsv
 
-# Build with replicate merging and expression filter
+# Build with expression filter
 # (manifest's `expression_attribute` column declares which GFF attribute
 # to read on each sample — here: `counts` for TALON samples)
-atroplex build -m manifest.tsv --min-replicates 2 --min-counts 3
+atroplex build -m manifest.tsv --min-counts 3
+
+# Build only specific chromosomes (for targeted analysis)
+atroplex build -m manifest.tsv --chromosomes chr1,chr22,chrX
 
 # Run full per-sample inspection (sharing, splicing hubs, diversity)
 atroplex inspect -m manifest.tsv -o results/
@@ -71,9 +74,6 @@ atroplex build -m ENCODE/manifest.tsv -o results/
 # From annotation files directly (metadata parsed from GFF headers)
 atroplex build -b gencode.gtf -b sample1.gtf -b sample2.gtf
 
-# With replicate merging (require feature in >= 2 replicates)
-atroplex build -m manifest.tsv --min-replicates 2
-
 # With expression filtering — thresholds are per-attribute and each sample
 # declares which attributes to read via the manifest's `expression_attribute`
 # column. A TALON manifest row with `expression_attribute = counts` is
@@ -82,6 +82,12 @@ atroplex build -m manifest.tsv --min-replicates 2
 # attributes on a given transcript are pass-through).
 atroplex build -m manifest.tsv --min-counts 3
 atroplex build -m manifest.tsv --min-cov 1 --min-TPM 0.5
+
+# Build only specific chromosomes
+atroplex build -m manifest.tsv --chromosomes chr1,chr22
+
+# Drop sample transcripts at novel loci (keep only annotated gene regions)
+atroplex build -m manifest.tsv --annotated-loci-only
 
 # Disable ISM absorption
 atroplex build -m manifest.tsv --no-absorb
@@ -135,17 +141,17 @@ atroplex discover -i reads.bam -m manifest.tsv -o results/
 Walks a built index and writes one GTF file per sample with gene, transcript, and exon lines. Expression values (when available) are emitted as GTF attributes. Supports filters to restrict output by sample, gene, region, biotype, source, or sample frequency.
 
 ```bash
-# Export all samples from a pre-built index
-atroplex export -g index.ggx -o export/
+# Export all samples from a pre-built index (pass the directory containing the .ggx)
+atroplex export -g index_dir/ -o export/
 
 # Export a specific sample, protein-coding genes only
-atroplex export -g index.ggx --sample HL60_M1_rep1 --biotype protein_coding
+atroplex export -g index_dir/ --sample HL60_M1_rep1 --biotype protein_coding
 
 # Export conserved features in a genomic region
-atroplex export -g index.ggx --region chr22:10000000-15000000 --conserved-only
+atroplex export -g index_dir/ --region chr22:10000000-15000000 --conserved-only
 
 # Export features present in at least 3 samples, from HAVANA
-atroplex export -g index.ggx --min-samples 3 --source HAVANA
+atroplex export -g index_dir/ --min-samples 3 --source HAVANA
 ```
 
 Export-specific options: `--sample`, `--gene`, `--region chr:start-end`, `--min-samples`, `--conserved-only`, `--biotype`, `--source` (all filters are AND'd).
@@ -160,7 +166,7 @@ Export-specific options: `--sample`, `--gene`, `--region chr:start-end`, `--min-
 | `--progress` | Show progress output |
 | `-m, --manifest` | Sample manifest file (TSV) |
 | `-b, --build-from` | Build from GFF/GTF file(s) |
-| `-g, --genogrove` | Load pre-built genogrove index (.ggx) |
+| `-g, --genogrove` | Directory containing a pre-built genogrove index (`.ggx` + optional `.qtx` sidecar) |
 | `-k, --order` | Genogrove tree order (default: 3) |
 | `--min-counts` | Minimum `counts` value for transcripts whose sample declares `counts` in its manifest `expression_attribute` column (default: -1, disabled) |
 | `--min-TPM` | Minimum `TPM` value for transcripts whose sample declares `TPM` (default: -1, disabled) |
@@ -169,9 +175,10 @@ Export-specific options: `--sample`, `--gene`, `--region chr:start-end`, `--min-
 | `--min-cov` | Minimum `cov` value for transcripts whose sample declares `cov` (default: -1, disabled) |
 | `--no-absorb` | Disable ISM segment absorption into longer parent segments |
 | `--fuzzy-tolerance` | Max bp difference for fuzzy exon boundary matching (default: 5) |
-| `--min-replicates` | Merge biological replicates; require features in >= N replicates (default: 0, no merge) |
 | `--prune-tombstones` | Physically remove absorbed segments from the grove post-build (slower, smaller .ggx) |
 | `--include-scaffolds` | Keep transcripts on unplaced scaffolds, alt contigs, fix patches, and decoy sequences. Default: off — GFF/BAM ingest is filtered to canonical main chromosomes only (`chr1..chr22`, `chrX`, `chrY`, `chrM`). Enable for non-human/non-mouse species or when you specifically need scaffold contributions. |
+| `--chromosomes` | Restrict index to specific chromosomes (comma-separated, e.g. `chr1,chr22,chrX`). Accepts both prefixed and bare names. Default: all chromosomes. |
+| `--annotated-loci-only` | Only keep sample transcripts that overlap an annotation segment. Novel intergenic loci are discarded; novel isoforms at annotated loci inherit the annotation gene identity. |
 
 ## Input Files
 
@@ -276,15 +283,6 @@ Absorption rules (in execution order):
 | 4 | Internal fragment (both ends missing) | Drop vs ref, Keep vs sample |
 
 After creating a new segment, reverse absorption applies the same rules to existing shorter segments. Matching uses pointer identity first, then fuzzy coordinate matching within `--fuzzy-tolerance` bp. Absorption can be disabled with `--no-absorb`.
-
-## Biological Replicate Merging
-
-When `--min-replicates N` is provided, biological replicates within the same experiment group are merged after grove construction:
-
-- Groups are determined by the `group` column in the manifest, or auto-inferred by stripping `_repNN` suffix from sample IDs
-- Features must be present in >= N replicates to survive (threshold capped at group size)
-- Expression values are averaged across replicates
-- Original replicate entries are excluded from downstream statistics
 
 ## Output Files
 

--- a/src/analysis_report.cpp
+++ b/src/analysis_report.cpp
@@ -475,9 +475,13 @@ void analysis_report::collect(grove_type& grove,
 
     // ── Traverse grove ──────────────────────────────────────────────
     auto roots = grove.get_root_nodes();
+    size_t chr_done = 0;
+    size_t chr_total = roots.size();
+    logging::progress_start();
 
     for (auto& [seqid, root] : roots) {
         if (!root) continue;
+        chr_done++;
         active_genes.clear();
         exon_expr_sum.clear();
 
@@ -488,7 +492,16 @@ void analysis_report::collect(grove_type& grove,
             node = children[0];
         }
 
+        size_t chr_leaves = 0;
+        size_t chr_segments = 0;
+
         while (node) {
+            chr_leaves++;
+            if (chr_leaves % 100 == 0) {
+                logging::progress(chr_leaves, "Inspecting " + seqid + " [leaf " +
+                    std::to_string(chr_leaves) + ", " +
+                    std::to_string(chr_segments) + " segments]");
+            }
             for (auto* key : node->get_keys()) {
                 auto& feature = key->get_data();
                 if (!is_segment(feature)) continue;
@@ -496,6 +509,7 @@ void analysis_report::collect(grove_type& grove,
                 auto& seg = get_segment(feature);
                 if (seg.absorbed) continue;
                 if (min_samples > 0 && seg.sample_count() < min_samples) continue;
+                chr_segments++;
 
                 // ── Segment → per-sample ────────────────────────────
                 size_t seg_sample_count = seg.sample_count();
@@ -752,6 +766,8 @@ void analysis_report::collect(grove_type& grove,
         active_genes.clear();
         exon_expr_sum.clear();
     }
+
+    logging::progress(chr_total, "Inspecting [" + std::to_string(chr_done) + "/" + std::to_string(chr_total) + " chromosomes] done");
 
     total_exons = visited_exons.size();
     total_edges = grove.edge_count();


### PR DESCRIPTION
## Summary
- Inspect traversal reports per-leaf-node progress when `--progress` is enabled: `Inspecting chr1 [leaf 100, 12450 segments]` — updates every 100 leaves per chromosome
- README updated: added `--chromosomes` and `--annotated-loci-only`, removed `--min-replicates` and "Biological Replicate Merging" section, `-g` now takes a directory, genogrove version bumped to v0.21.0

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] `atroplex inspect --progress` shows per-chromosome leaf/segment updates
- [x] All tests pass