### PR TITLE
Always inherit gene_idx from annotation overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`--annotated-loci-only` build filter** (#43): drops sample transcripts that don't spatially overlap any annotation segment on the same strand. Novel isoforms at annotated loci inherit the annotation's `gene_idx`, so sample-specific gene_ids (MSTRG.*, ENCLB*) no longer inflate the gene count. Annotation transcripts always pass. Docker CI now pushes PR images tagged `pr-<N>` for HPC testing; build log shows per-file segment delta; overview renames `transcripts` to `source_transcript_ids`.
 
+### Changed
+- **Gene_idx inheritance always applied** ([#63](https://github.com/ylab-hi/atroplex/pull/63)): sample transcripts that spatially overlap an annotation segment now always inherit its gene_idx, regardless of `--annotated-loci-only`. Previously this was gated behind the flag, causing 19M inflated gene counts on 21K-sample builds without it (each StringTie gene_id created a separate gene entry). `--annotated-loci-only` now only controls whether novel-locus transcripts are kept or dropped.
+
 ### Fixed
 - **Duplicate .qtx records at merge time** ([#62](https://github.com/ylab-hi/atroplex/pull/62), fixes [#35](https://github.com/ylab-hi/atroplex/issues/35), [#58](https://github.com/ylab-hi/atroplex/issues/58)): `flush_block` in `run_final_merge` now collapses duplicate `(segment, sample)` pairs by summing values before writing. Removes inconsistent reader-side workarounds. Also standardizes file-open error logging in `analysis_report` and adds stream read checks to `.ggx` deserialization.
 - **`is_annotation_sample` checked `annotation_source` field, not just `type`**: samples with `annotation_source` filled in the manifest (common in StringTie GTFs built against a reference) were misclassified as annotations, bypassing the `--annotated-loci-only` filter and gene_idx inheritance. Fix: check `info.type == "annotation"` only.

--- a/src/segment_builder.cpp
+++ b/src/segment_builder.cpp
@@ -223,38 +223,32 @@ void segment_builder::create_segment(
         }
     }
 
-    // Annotated-loci-only filter: if the flag is set and this is a
-    // SAMPLE transcript (not annotation), require at least one spatial
-    // candidate from an annotation source. Annotation transcripts always
-    // pass — they ARE the reference loci. Transcripts that merged into
-    // existing segments via Rules 0-5 already returned above.
-    if (annotated_loci_only && !is_annotation_sample(sample_id)) {
-        bool overlaps_annotation = false;
+    // Gene_idx inheritance: sample transcripts that overlap an annotation
+    // segment always inherit its gene_idx so novel isoforms at known loci
+    // don't inflate the gene count with sample-specific gene_ids (MSTRG.*,
+    // ENCLB*, etc.). Not gated behind --annotated-loci-only — this is
+    // always the right behavior when an annotation overlap exists.
+    // Only for sample transcripts — annotations keep their own gene_idx.
+    // Without this guard, overlapping annotation genes on the same strand
+    // would steal each other's gene_idx.
+    bool overlaps_annotation = false;
+    if (!is_annotation_sample(sample_id)) {
         for (const auto& cand : candidates) {
             if (is_parent_annotation(cand.segment)) {
+                gene_idx = get_segment(cand.segment->get_data()).gene_idx;
                 overlaps_annotation = true;
                 break;
             }
         }
-        if (!overlaps_annotation) {
-            counters.discarded_transcripts++;
-            return;
-        }
     }
 
-    // When overlapping an annotation segment, inherit its gene_idx so
-    // novel isoforms at known loci don't inflate the gene count with
-    // sample-specific gene_ids (MSTRG.*, ENCLB*, etc.).
-    // Only for sample transcripts — annotations already have the correct
-    // gene_idx from their own GTF. Without this guard, overlapping
-    // annotation genes on the same strand would steal each other's gene_idx.
-    if (annotated_loci_only && !is_annotation_sample(sample_id)) {
-        for (const auto& cand : candidates) {
-            if (is_parent_annotation(cand.segment)) {
-                gene_idx = get_segment(cand.segment->get_data()).gene_idx;
-                break;
-            }
-        }
+    // Annotated-loci-only filter: if the flag is set and this is a
+    // SAMPLE transcript with no annotation overlap, discard it.
+    // Annotation transcripts always pass. Transcripts that merged into
+    // existing segments via Rules 0-5 already returned above.
+    if (annotated_loci_only && !is_annotation_sample(sample_id) && !overlaps_annotation) {
+        counters.discarded_transcripts++;
+        return;
     }
 
     // Step 5: Create new segment


### PR DESCRIPTION
## Summary
- Gene_idx inheritance from annotation segments is no longer gated behind `--annotated-loci-only` — it always applies for sample transcripts that spatially overlap an annotation segment
- `--annotated-loci-only` now only controls whether sample transcripts at **novel loci** (no annotation overlap) are kept or dropped
- Fixes 19M→78K gene count inflation on 21K-sample builds without requiring `--annotated-loci-only`

## Known limitations
- When `--no-absorb` is set, `candidates` is empty so inheritance is a no-op (spatial query only runs for absorption). Documented; `--no-absorb` is rarely used with mixed annotation+sample builds.
- First-wins tie-breaking for multiple overlapping annotation segments (related to #44).

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] Gene count matches annotated-loci-only build (~78K) even without the flag
- [x] `--annotated-loci-only` still drops novel-locus transcripts
- [x] Annotation gene_idx is not stolen between overlapping annotation genes
- [x] All existing tests pass