### PR TITLE
Consolidate build parameters into build_options struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`--annotated-loci-only` build filter** (#43): drops sample transcripts that don't spatially overlap any annotation segment on the same strand. Novel isoforms at annotated loci inherit the annotation's `gene_idx`, so sample-specific gene_ids (MSTRG.*, ENCLB*) no longer inflate the gene count. Annotation transcripts always pass. Docker CI now pushes PR images tagged `pr-<N>` for HPC testing; build log shows per-file segment delta; overview renames `transcripts` to `source_transcript_ids`.
 
 ### Changed
+- **Consolidate build parameters into `build_options` struct** ([#67](https://github.com/ylab-hi/atroplex/pull/67), closes [#57](https://github.com/ylab-hi/atroplex/issues/57)): replaces 13-15 individual parameters on `build_from_samples`, `build_gff::build`, `build_bam::build`, `process_gene`, and `process_transcript` with a single struct. Net -63 lines.
 - **Gene_idx inheritance always applied** ([#63](https://github.com/ylab-hi/atroplex/pull/63)): sample transcripts that spatially overlap an annotation segment now always inherit its gene_idx, regardless of `--annotated-loci-only`. Previously this was gated behind the flag, causing 19M inflated gene counts on 21K-sample builds without it (each StringTie gene_id created a separate gene entry). `--annotated-loci-only` now only controls whether novel-locus transcripts are kept or dropped.
 
 ### Fixed

--- a/include/build_bam.hpp
+++ b/include/build_bam.hpp
@@ -55,14 +55,9 @@ public:
                       chromosome_exon_caches& exon_caches,
                       chromosome_segment_caches& segment_caches,
                       size_t& segment_count,
-                      const expression_filters& filters,
-                      bool absorb,
-                      size_t fuzzy_tolerance,
-                      bool include_scaffolds,
+                      const build_options& opts,
                       build_counters& counters,
-                      quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr,
-                      bool annotated_loci_only = false,
-                      const std::unordered_set<std::string>& chromosomes_filter = {});
+                      quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr);
 
     /**
      * Parse BAM header to extract sample metadata.

--- a/include/build_gff.hpp
+++ b/include/build_gff.hpp
@@ -62,15 +62,9 @@ public:
                       chromosome_exon_caches& exon_caches,
                       chromosome_segment_caches& segment_caches,
                       size_t& segment_count,
-                      uint32_t num_threads,
-                      const expression_filters& filters,
-                      bool absorb,
-                      size_t fuzzy_tolerance,
-                      bool include_scaffolds,
+                      const build_options& opts,
                       build_counters& counters,
-                      quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr,
-                      bool annotated_loci_only = false,
-                      const std::unordered_set<std::string>& chromosomes_filter = {});
+                      quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr);
 
     /**
      * Parse GTF/GFF header to extract sample metadata
@@ -121,12 +115,9 @@ public:
         segment_cache_type& segment_cache,
         std::optional<uint32_t> sample_id,
         size_t& segment_count,
-        const expression_filters& filters,
-        bool absorb,
-        size_t fuzzy_tolerance,
+        const build_options& opts,
         build_counters& counters,
-        quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr,
-        bool annotated_loci_only = false
+        quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr
     );
 
 private:
@@ -139,12 +130,9 @@ private:
         std::unordered_map<std::string, key_ptr>& segment_keys,
         std::optional<uint32_t> sample_id,
         size_t& segment_count,
-        const expression_filters& filters,
-        bool absorb,
-        size_t fuzzy_tolerance,
+        const build_options& opts,
         build_counters& counters,
-        quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr,
-        bool annotated_loci_only = false
+        quant_sidecar::SampleStreamWriter* sidecar_writer = nullptr
     );
 
     /**

--- a/include/build_summary.hpp
+++ b/include/build_summary.hpp
@@ -14,9 +14,11 @@
 #include <cstddef>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "genomic_feature.hpp"
+#include "sample_info.hpp"
 
 /**
  * Lightweight counters tracking transcript disposition during grove build.
@@ -50,6 +52,18 @@ struct build_counters {
     size_t absorbed_segments = 0;
     size_t discarded_transcripts = 0;
     size_t scaffold_filtered_transcripts = 0;
+};
+
+struct build_options {
+    uint32_t threads = 1;
+    expression_filters filters;
+    bool absorb = true;
+    size_t fuzzy_tolerance = 5;
+    bool prune_tombstones = false;
+    bool include_scaffolds = false;
+    std::string qtx_path;
+    bool annotated_loci_only = false;
+    std::unordered_set<std::string> chromosomes_filter;
 };
 
 /**

--- a/include/builder.hpp
+++ b/include/builder.hpp
@@ -52,16 +52,8 @@ public:
     static build_summary build_from_samples(
         grove_type& grove,
         const std::vector<sample_info>& samples,
-        uint32_t threads,
-        const expression_filters& filters,
-        bool absorb,
-        size_t fuzzy_tolerance,
-        bool prune_tombstones,
-        bool include_scaffolds = false,
-        const std::string& qtx_path = "",
-        chromosome_exon_caches* out_exon_caches = nullptr,
-        bool annotated_loci_only = false,
-        const std::unordered_set<std::string>& chromosomes_filter = {}
+        const build_options& opts = {},
+        chromosome_exon_caches* out_exon_caches = nullptr
     );
 
     /**

--- a/src/build_bam.cpp
+++ b/src/build_bam.cpp
@@ -24,14 +24,9 @@ void build_bam::build(grove_type& grove,
     chromosome_exon_caches& exon_caches,
     chromosome_segment_caches& segment_caches,
     size_t& segment_count,
-    const expression_filters& filters,
-    bool absorb,
-    size_t fuzzy_tolerance,
-    bool include_scaffolds,
+    const build_options& opts,
     build_counters& counters,
-    quant_sidecar::SampleStreamWriter* sidecar_writer,
-    bool annotated_loci_only,
-    const std::unordered_set<std::string>& chromosomes_filter) {
+    quant_sidecar::SampleStreamWriter* sidecar_writer) {
 
     const size_t segment_count_before = segment_count;
 
@@ -60,13 +55,13 @@ void build_bam::build(grove_type& grove,
         // cluster represents one transcript-level unit, so we count
         // it against scaffold_filtered_transcripts and bail before
         // bumping input_transcripts.
-        if (!is_main_chromosome(cluster.seqid, include_scaffolds)) {
+        if (!is_main_chromosome(cluster.seqid, opts.include_scaffolds)) {
             counters.scaffold_filtered_transcripts++;
             continue;
         }
 
-        if (!chromosomes_filter.empty() &&
-            chromosomes_filter.find(normalize_chromosome(cluster.seqid)) == chromosomes_filter.end()) {
+        if (!opts.chromosomes_filter.empty() &&
+            opts.chromosomes_filter.find(normalize_chromosome(cluster.seqid)) == opts.chromosomes_filter.end()) {
             continue;
         }
 
@@ -76,7 +71,7 @@ void build_bam::build(grove_type& grove,
         // only have a read-count signal, so only `--min-counts` applies.
         // Other attribute thresholds (TPM/FPKM/cov) are a no-op for BAM.
         float read_count = static_cast<float>(cluster.read_count());
-        if (filters.min_counts >= 0 && read_count < filters.min_counts) {
+        if (opts.filters.min_counts >= 0 && read_count < opts.filters.min_counts) {
             counters.discarded_transcripts++;
             continue;
         }
@@ -123,8 +118,8 @@ void build_bam::build(grove_type& grove,
             segment_caches[seqid], seg_gene_idx,
             sample_id, "BAM", segment_count,
             read_count, "",
-            absorb, fuzzy_tolerance,
-            counters, sidecar_writer, annotated_loci_only
+            opts.absorb, opts.fuzzy_tolerance,
+            counters, sidecar_writer, opts.annotated_loci_only
         );
     }
 

--- a/src/build_gff.cpp
+++ b/src/build_gff.cpp
@@ -28,15 +28,9 @@ void build_gff::build(grove_type& grove,
     chromosome_exon_caches& exon_caches,
     chromosome_segment_caches& segment_caches,
     size_t& segment_count,
-    uint32_t /*num_threads*/,
-    const expression_filters& filters,
-    bool absorb,
-    size_t fuzzy_tolerance,
-    bool include_scaffolds,
+    const build_options& opts,
     build_counters& counters,
-    quant_sidecar::SampleStreamWriter* sidecar_writer,
-    bool annotated_loci_only,
-    const std::unordered_set<std::string>& chromosomes_filter) {
+    quant_sidecar::SampleStreamWriter* sidecar_writer) {
 
     gio::gff_reader reader(filepath.string());
     const size_t segment_count_before = segment_count;
@@ -67,15 +61,15 @@ void build_gff::build(grove_type& grove,
         // the filter for non-human/non-mouse use cases. We only count the
         // transcript-level entries so `scaffold_filtered_transcripts`
         // mirrors the `input_transcripts` semantics.
-        if (!is_main_chromosome(entry.seqid, include_scaffolds)) {
+        if (!is_main_chromosome(entry.seqid, opts.include_scaffolds)) {
             if (entry.type == "transcript") {
                 counters.scaffold_filtered_transcripts++;
             }
             continue;
         }
 
-        if (!chromosomes_filter.empty() &&
-            chromosomes_filter.find(normalize_chromosome(entry.seqid)) == chromosomes_filter.end()) {
+        if (!opts.chromosomes_filter.empty() &&
+            opts.chromosomes_filter.find(normalize_chromosome(entry.seqid)) == opts.chromosomes_filter.end()) {
             continue;
         }
 
@@ -90,8 +84,7 @@ void build_gff::build(grove_type& grove,
         if (!current_gene_id.empty() && gene_id.value() != current_gene_id) {
             process_gene(grove, grove_mutex, current_gene_entries,
                 exon_caches[current_chrom], segment_caches[current_chrom],
-                sample_id, segment_count, filters, absorb, fuzzy_tolerance, counters,
-                sidecar_writer, annotated_loci_only);
+                sample_id, segment_count, opts, counters, sidecar_writer);
             current_gene_entries.clear();
         }
 
@@ -103,8 +96,7 @@ void build_gff::build(grove_type& grove,
     if (!current_gene_entries.empty()) {
         process_gene(grove, grove_mutex, current_gene_entries,
             exon_caches[current_chrom], segment_caches[current_chrom],
-            sample_id, segment_count, filters, absorb, fuzzy_tolerance, counters,
-            sidecar_writer, annotated_loci_only);
+            sample_id, segment_count, opts, counters, sidecar_writer);
     }
 
     logging::progress_done(segment_count, segment_count - segment_count_before,
@@ -119,12 +111,9 @@ void build_gff::process_gene(
     segment_cache_type& segment_cache,
     std::optional<uint32_t> sample_id,
     size_t& segment_count,
-    const expression_filters& filters,
-    bool absorb,
-    size_t fuzzy_tolerance,
+    const build_options& opts,
     build_counters& counters,
-    quant_sidecar::SampleStreamWriter* sidecar_writer,
-    bool annotated_loci_only
+    quant_sidecar::SampleStreamWriter* sidecar_writer
 ) {
     std::unordered_map<std::string, std::vector<gio::gff_entry>> transcripts;
     for (const auto& entry : gene_entries) {
@@ -155,7 +144,7 @@ void build_gff::process_gene(
     for (const auto& transcript_id : tx_order) {
         process_transcript(grove, grove_mutex, transcript_id, transcripts[transcript_id],
             exon_cache, segment_cache, sample_id, segment_count,
-            filters, absorb, fuzzy_tolerance, counters, sidecar_writer, annotated_loci_only);
+            opts, counters, sidecar_writer);
     }
 }
 
@@ -168,12 +157,9 @@ void build_gff::process_transcript(
     std::unordered_map<std::string, key_ptr>& segment_cache,
     std::optional<uint32_t> sample_id,
     size_t& segment_count,
-    const expression_filters& filters,
-    bool absorb,
-    size_t fuzzy_tolerance,
+    const build_options& opts,
     build_counters& counters,
-    quant_sidecar::SampleStreamWriter* sidecar_writer,
-    bool annotated_loci_only
+    quant_sidecar::SampleStreamWriter* sidecar_writer
 ) {
     // Step 1: Extract and sort exons in 5'→3' biological order
     std::vector<gio::gff_entry> sorted_exons = extract_sorted_exons(transcript_entries);
@@ -242,7 +228,7 @@ void build_gff::process_transcript(
                 // Evaluate the filter for this attribute (AND semantics):
                 // skip if the CLI threshold is set and the transcript's
                 // value is below it.
-                float threshold = filters.for_attribute(attr);
+                float threshold = opts.filters.for_attribute(attr);
                 if (threshold >= 0 && value < threshold) {
                     drop_by_filter = true;
                 }
@@ -310,8 +296,8 @@ void build_gff::process_transcript(
         grove, grove_mutex, transcript_id, seqid, strand,
         min_it->start, max_it->end, static_cast<int>(sorted_exons.size()),
         exon_coords, exon_chain, segment_cache, gene_idx, sample_id,
-        gff_source, segment_count, expression_value, transcript_biotype, absorb, fuzzy_tolerance,
-        counters, sidecar_writer, annotated_loci_only
+        gff_source, segment_count, expression_value, transcript_biotype,
+        opts.absorb, opts.fuzzy_tolerance, counters, sidecar_writer, opts.annotated_loci_only
     );
 }
 

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -50,16 +50,8 @@ static bool chromosome_compare(const std::string& a, const std::string& b) {
 
 build_summary builder::build_from_samples(grove_type& grove,
                                   const std::vector<sample_info>& samples,
-                                  uint32_t threads,
-                                  const expression_filters& filters,
-                                  bool absorb,
-                                  size_t fuzzy_tolerance,
-                                  bool prune_tombstones,
-                                  bool include_scaffolds,
-                                  const std::string& qtx_path,
-                                  chromosome_exon_caches* out_exon_caches,
-                                  bool annotated_loci_only,
-                                  const std::unordered_set<std::string>& chromosomes_filter) {
+                                  const build_options& opts,
+                                  chromosome_exon_caches* out_exon_caches) {
     if (samples.empty()) {
         logging::warning("No samples provided to build genogrove");
         return {};
@@ -68,7 +60,7 @@ build_summary builder::build_from_samples(grove_type& grove,
     // Per-build counters threaded through build_gff / build_bam / segment_builder
     build_counters counters;
 
-    if (threads > 1) {
+    if (opts.threads > 1) {
         logging::info("Note: Multi-threading for build not yet optimized, using single thread");
     }
 
@@ -86,9 +78,9 @@ build_summary builder::build_from_samples(grove_type& grove,
     // merge_to_qtx's own atomic-rename scratch file.)
     std::filesystem::path qtx_output_path;
     std::filesystem::path qtx_temp_dir;
-    bool sidecar_enabled = !qtx_path.empty();
+    bool sidecar_enabled = !opts.qtx_path.empty();
     if (sidecar_enabled) {
-        qtx_output_path = qtx_path;
+        qtx_output_path = opts.qtx_path;
         // Use `.streams` suffix rather than `.tmp` to avoid collision
         // with merge_to_qtx's own atomic-rename scratch file, which
         // sits at `{qtx_path}.tmp`. The streams directory holds per-
@@ -190,7 +182,7 @@ build_summary builder::build_from_samples(grove_type& grove,
             open_sidecar(registry_id);
 
             // Build with persistent caches for cross-file deduplication
-            build_gff::build(grove, filepath, registry_id, exon_caches, segment_caches, segment_count, threads, filters, absorb, fuzzy_tolerance, include_scaffolds, counters, sidecar.get(), annotated_loci_only, chromosomes_filter);
+            build_gff::build(grove, filepath, registry_id, exon_caches, segment_caches, segment_count, opts, counters, sidecar.get());
         } else if (ftype == gio::filetype::BAM || ftype == gio::filetype::SAM) {
             logging::info("[" + std::to_string(current) + "/" + std::to_string(total) + "] Processing BAM: " + filepath.filename().string() +
                          (info.id.empty() ? "" : " (id: " + info.id + ")"));
@@ -199,8 +191,7 @@ build_summary builder::build_from_samples(grove_type& grove,
             open_sidecar(registry_id);
 
             build_bam::build(grove, filepath, registry_id, exon_caches, segment_caches,
-                            segment_count, filters, absorb, fuzzy_tolerance, include_scaffolds, counters, sidecar.get(),
-                            annotated_loci_only, chromosomes_filter);
+                            segment_count, opts, counters, sidecar.get());
         } else {
             logging::warning("Unsupported file type for: " + filepath.string());
         }
@@ -236,7 +227,7 @@ build_summary builder::build_from_samples(grove_type& grove,
     std::unordered_set<uint64_t> tombstoned_seg_indices;
     std::unordered_map<uint64_t, uint64_t> tombstone_remap;
     counters.absorbed_segments = remove_tombstones(
-        grove, segment_caches, prune_tombstones,
+        grove, segment_caches, opts.prune_tombstones,
         &tombstoned_seg_indices, &tombstone_remap);
 
     size_t live_segments = (segment_count >= counters.absorbed_segments)
@@ -245,7 +236,7 @@ build_summary builder::build_from_samples(grove_type& grove,
     std::string tombstone_note;
     if (counters.absorbed_segments > 0) {
         tombstone_note = " (" + std::to_string(counters.absorbed_segments)
-            + (prune_tombstones ? " tombstones pruned)" : " tombstones)");
+            + (opts.prune_tombstones ? " tombstones pruned)" : " tombstones)");
     }
     logging::info("Grove construction complete: " + std::to_string(live_segments)
         + " segments" + tombstone_note);
@@ -443,5 +434,7 @@ build_summary builder::build_from_files(grove_type& grove,
         samples.push_back(std::move(info));
     }
 
-    return build_from_samples(grove, samples, threads, expression_filters{}, true, 5, false, false, /*qtx_path=*/"", out_exon_caches);
+    build_options file_opts;
+    file_opts.threads = threads;
+    return build_from_samples(grove, samples, file_opts, out_exon_caches);
 }

--- a/src/subcall/subcall.cpp
+++ b/src/subcall/subcall.cpp
@@ -216,29 +216,31 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
 
     // Build grove if we have samples
     if (!all_samples.empty()) {
-        expression_filters filters;
-        filters.min_counts = args["min-counts"].as<float>();
-        filters.min_TPM    = args["min-TPM"].as<float>();
-        filters.min_FPKM   = args["min-FPKM"].as<float>();
-        filters.min_RPKM   = args["min-RPKM"].as<float>();
-        filters.min_cov    = args["min-cov"].as<float>();
+        build_options opts;
+        opts.threads = threads;
+        opts.filters.min_counts = args["min-counts"].as<float>();
+        opts.filters.min_TPM    = args["min-TPM"].as<float>();
+        opts.filters.min_FPKM   = args["min-FPKM"].as<float>();
+        opts.filters.min_RPKM   = args["min-RPKM"].as<float>();
+        opts.filters.min_cov    = args["min-cov"].as<float>();
+        opts.absorb = !args.count("no-absorb");
+        opts.fuzzy_tolerance = args["fuzzy-tolerance"].as<size_t>();
+        opts.prune_tombstones = args.count("prune-tombstones") > 0;
+        opts.include_scaffolds = include_scaffolds;
+        opts.annotated_loci_only = args.count("annotated-loci-only") > 0;
+        opts.chromosomes_filter = chromosomes_filter;
 
-        bool absorb = !args.count("no-absorb");
-        size_t fuzzy_tol = args["fuzzy-tolerance"].as<size_t>();
-        bool prune_tombstones = args.count("prune-tombstones") > 0;
         logging::info("Creating grove with order: " + std::to_string(order));
 
-        if (filters.any_active()) {
+        if (opts.filters.any_active()) {
             std::string note = "Expression filters:";
-            if (filters.min_counts >= 0) note += " counts>=" + std::to_string(filters.min_counts);
-            if (filters.min_TPM    >= 0) note += " TPM>="    + std::to_string(filters.min_TPM);
-            if (filters.min_FPKM   >= 0) note += " FPKM>="   + std::to_string(filters.min_FPKM);
-            if (filters.min_RPKM   >= 0) note += " RPKM>="   + std::to_string(filters.min_RPKM);
-            if (filters.min_cov    >= 0) note += " cov>="    + std::to_string(filters.min_cov);
+            if (opts.filters.min_counts >= 0) note += " counts>=" + std::to_string(opts.filters.min_counts);
+            if (opts.filters.min_TPM    >= 0) note += " TPM>="    + std::to_string(opts.filters.min_TPM);
+            if (opts.filters.min_FPKM   >= 0) note += " FPKM>="   + std::to_string(opts.filters.min_FPKM);
+            if (opts.filters.min_RPKM   >= 0) note += " RPKM>="   + std::to_string(opts.filters.min_RPKM);
+            if (opts.filters.min_cov    >= 0) note += " cov>="    + std::to_string(opts.filters.min_cov);
             logging::info(note);
 
-            // Warn if a filter is set but no sample declares that attribute
-            // in its manifest `expression_attribute` column.
             auto any_sample_declares = [&](const std::string& attr) {
                 for (const auto& s : all_samples) {
                     for (const auto& a : s.expression_attributes) {
@@ -254,42 +256,40 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
                         "` in its expression_attribute column — filter has no effect");
                 }
             };
-            check("counts", filters.min_counts);
-            check("TPM",    filters.min_TPM);
-            check("FPKM",   filters.min_FPKM);
-            check("RPKM",   filters.min_RPKM);
-            check("cov",    filters.min_cov);
+            check("counts", opts.filters.min_counts);
+            check("TPM",    opts.filters.min_TPM);
+            check("FPKM",   opts.filters.min_FPKM);
+            check("RPKM",   opts.filters.min_RPKM);
+            check("cov",    opts.filters.min_cov);
         }
 
-        if (!absorb) {
+        if (!opts.absorb) {
             logging::info("ISM segment absorption disabled");
-        } else if (fuzzy_tol > 0) {
-            logging::info("Fuzzy absorption tolerance: " + std::to_string(fuzzy_tol) + "bp");
+        } else if (opts.fuzzy_tolerance > 0) {
+            logging::info("Fuzzy absorption tolerance: " + std::to_string(opts.fuzzy_tolerance) + "bp");
         }
-        if (prune_tombstones) {
+        if (opts.prune_tombstones) {
             logging::info("Physical tombstone removal enabled (--prune-tombstones)");
         }
-        if (include_scaffolds) {
+        if (opts.include_scaffolds) {
             logging::info("Scaffold filter disabled (--include-scaffolds): all seqids retained");
         } else {
             logging::info("Scaffold filter active: main chromosomes only (chr1..chr22, chrX, chrY, chrM)");
         }
-        if (!chromosomes_filter.empty()) {
+        if (!opts.chromosomes_filter.empty()) {
             std::string chr_list;
-            for (const auto& c : chromosomes_filter) {
+            for (const auto& c : opts.chromosomes_filter) {
                 if (!chr_list.empty()) chr_list += ", ";
                 chr_list += c;
             }
             logging::info("Chromosome filter active: " + chr_list);
         }
+        if (opts.annotated_loci_only) {
+            logging::info("Annotated-loci-only mode: sample transcripts at novel loci will be discarded");
+        }
         grove = std::make_unique<grove_type>(order);
 
-        // Derive the final single-file quantification sidecar path. We
-        // reuse the resolved output_dir + prefix so the .qtx lands next
-        // to the .ggx and is self-identifying. Per-sample temp streams
-        // are written under `{qtx_path}.tmp/` by build_from_samples and
-        // K-way merged into this single file at end of build.
-        std::string qtx_path;
+        // Derive the final single-file quantification sidecar path.
         {
             std::string fallback_for_outdir;
             if (args.count("manifest")) {
@@ -300,51 +300,47 @@ void subcall::setup_grove(const cxxopts::ParseResult& args) {
             auto out_dir = resolve_output_dir(args, fallback_for_outdir);
             std::string prefix = resolve_prefix(args);
             if (!out_dir.empty()) {
-                qtx_path = (out_dir / (prefix + ".qtx")).string();
+                opts.qtx_path = (out_dir / (prefix + ".qtx")).string();
             }
         }
 
         auto build_start = std::chrono::steady_clock::now();
-        bool annotated_only = args.count("annotated-loci-only") > 0;
-        if (annotated_only) {
-            logging::info("Annotated-loci-only mode: sample transcripts at novel loci will be discarded");
-        }
-        build_stats = builder::build_from_samples(*grove, all_samples, threads, filters, absorb, fuzzy_tol, prune_tombstones, include_scaffolds, qtx_path, &exon_caches_, annotated_only, chromosomes_filter);
+        build_stats = builder::build_from_samples(*grove, all_samples, opts, &exon_caches_);
         auto build_elapsed = std::chrono::duration<double>(std::chrono::steady_clock::now() - build_start).count();
         build_stats->build_time_seconds = build_elapsed;
 
         // Record build parameters for summary provenance
         build_stats->build_parameters["order"] = std::to_string(order);
-        build_stats->build_parameters["absorb"] = absorb ? "yes" : "no";
-        if (absorb && fuzzy_tol > 0)
-            build_stats->build_parameters["fuzzy_tolerance"] = std::to_string(fuzzy_tol) + "bp";
-        build_stats->build_parameters["include_scaffolds"] = include_scaffolds ? "yes" : "no";
-        build_stats->build_parameters["annotated_loci_only"] = annotated_only ? "yes" : "no";
-        if (!chromosomes_filter.empty()) {
+        build_stats->build_parameters["absorb"] = opts.absorb ? "yes" : "no";
+        if (opts.absorb && opts.fuzzy_tolerance > 0)
+            build_stats->build_parameters["fuzzy_tolerance"] = std::to_string(opts.fuzzy_tolerance) + "bp";
+        build_stats->build_parameters["include_scaffolds"] = opts.include_scaffolds ? "yes" : "no";
+        build_stats->build_parameters["annotated_loci_only"] = opts.annotated_loci_only ? "yes" : "no";
+        if (!opts.chromosomes_filter.empty()) {
             std::string chr_list;
-            for (const auto& c : chromosomes_filter) {
+            for (const auto& c : opts.chromosomes_filter) {
                 if (!chr_list.empty()) chr_list += ",";
                 chr_list += c;
             }
             build_stats->build_parameters["chromosomes"] = chr_list;
         }
-        if (filters.min_counts >= 0)
-            build_stats->build_parameters["min_counts"] = std::to_string(static_cast<int>(filters.min_counts));
-        if (filters.min_TPM >= 0)
-            build_stats->build_parameters["min_TPM"] = std::to_string(static_cast<int>(filters.min_TPM));
-        if (filters.min_FPKM >= 0)
-            build_stats->build_parameters["min_FPKM"] = std::to_string(static_cast<int>(filters.min_FPKM));
-        if (filters.min_RPKM >= 0)
-            build_stats->build_parameters["min_RPKM"] = std::to_string(static_cast<int>(filters.min_RPKM));
-        if (filters.min_cov >= 0)
-            build_stats->build_parameters["min_cov"] = std::to_string(static_cast<int>(filters.min_cov));
+        if (opts.filters.min_counts >= 0)
+            build_stats->build_parameters["min_counts"] = std::to_string(static_cast<int>(opts.filters.min_counts));
+        if (opts.filters.min_TPM >= 0)
+            build_stats->build_parameters["min_TPM"] = std::to_string(static_cast<int>(opts.filters.min_TPM));
+        if (opts.filters.min_FPKM >= 0)
+            build_stats->build_parameters["min_FPKM"] = std::to_string(static_cast<int>(opts.filters.min_FPKM));
+        if (opts.filters.min_RPKM >= 0)
+            build_stats->build_parameters["min_RPKM"] = std::to_string(static_cast<int>(opts.filters.min_RPKM));
+        if (opts.filters.min_cov >= 0)
+            build_stats->build_parameters["min_cov"] = std::to_string(static_cast<int>(opts.filters.min_cov));
 
         logging::info("Grove ready with spatial index and graph structure");
 
         // Open the qtx reader we just produced so the subclass execute()
         // can use it directly without reloading from disk.
-        if (!qtx_path.empty()) {
-            try_open_qtx_for(qtx_path, qtx_reader);
+        if (!opts.qtx_path.empty()) {
+            try_open_qtx_for(opts.qtx_path, qtx_reader);
         }
     }
 }

--- a/tests/build/absorption_test.cpp
+++ b/tests/build/absorption_test.cpp
@@ -54,9 +54,11 @@ protected:
         uint32_t sample_id = sample_registry::instance().register_data(info);
 
         build_counters counters;
+        build_options test_opts;
+        test_opts.absorb = absorb;
+        test_opts.include_scaffolds = true;
         build_gff::build(*grove, fixture, sample_id, exon_caches, segment_caches,
-                         segment_count, 0, expression_filters{}, absorb, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count, test_opts, counters);
 
         size_t absorbed = 0, live = 0, total_absorbed_into = 0, live_tx_count = 0;
         auto roots = grove->get_root_nodes();
@@ -109,17 +111,18 @@ protected:
         sample_info info1("sample1");
         if (file1_annotation) { info1.type = "annotation"; info1.annotation_source = "GENCODE"; }
         uint32_t sid1 = sample_registry::instance().register_data(info1);
+        build_options test_opts;
+        test_opts.absorb = absorb;
+        test_opts.include_scaffolds = true;
         build_gff::build(*grove, fix1, sid1, exon_caches, segment_caches,
-                         segment_count, 0, expression_filters{}, absorb, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count, test_opts, counters);
 
         // File 2
         sample_info info2("sample2");
         if (file2_annotation) { info2.type = "annotation"; info2.annotation_source = "GENCODE"; }
         uint32_t sid2 = sample_registry::instance().register_data(info2);
         build_gff::build(*grove, fix2, sid2, exon_caches, segment_caches,
-                         segment_count, 0, expression_filters{}, absorb, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count, test_opts, counters);
 
         size_t absorbed = 0, live = 0, total_absorbed_into = 0, live_tx_count = 0;
         auto roots = grove->get_root_nodes();

--- a/tests/build/builder_pipeline_test.cpp
+++ b/tests/build/builder_pipeline_test.cpp
@@ -148,11 +148,7 @@ TEST_F(BuilderPipelineTest, BuilderFullPipeline_CountersPopulated) {
     samples.back().type = "sample";
 
     grove_type grove(3);
-    auto summary = builder::build_from_samples(
-        grove, samples,
-        /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*fuzzy_tolerance=*/5,
-        /*prune_tombstones=*/false);
+    auto summary = builder::build_from_samples(grove, samples);
 
     // 2 transcripts read from the two files
     EXPECT_EQ(summary.counters.input_transcripts, 2u);
@@ -193,11 +189,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_DefaultKeepsInTree) {
 
     grove_type grove(3);
     // prune_tombstones = false (default)
-    auto summary = builder::build_from_samples(
-        grove, samples,
-        /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*fuzzy_tolerance=*/5,
-        /*prune_tombstones=*/false);
+    auto summary = builder::build_from_samples(grove, samples);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u)
         << "Fixture must produce exactly one tombstone";
@@ -236,11 +228,9 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagPhysicallyRemoves) {
     samples.back().type = "sample";
 
     grove_type grove(3);
-    auto summary = builder::build_from_samples(
-        grove, samples,
-        /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*fuzzy_tolerance=*/5,
-        /*prune_tombstones=*/true);
+    build_options prune_opts;
+    prune_opts.prune_tombstones = true;
+    auto summary = builder::build_from_samples(grove, samples, prune_opts);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u);
 
@@ -274,11 +264,9 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
         samples.back().type = "sample";
 
         grove_type grove(3);
-        auto summary = builder::build_from_samples(
-            grove, samples,
-            /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-            /*fuzzy_tolerance=*/5,
-            /*prune_tombstones=*/true);
+        build_options prune_opts;
+        prune_opts.prune_tombstones = true;
+        auto summary = builder::build_from_samples(grove, samples, prune_opts);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
         pruned_edge_count = grove.edge_count();
     }
@@ -298,11 +286,7 @@ TEST_F(BuilderPipelineTest, RemoveTombstones_PruneFlagDropsOrphanEdges) {
         samples.back().type = "sample";
 
         grove_type grove(3);
-        auto summary = builder::build_from_samples(
-            grove, samples,
-            /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-            /*fuzzy_tolerance=*/5,
-            /*prune_tombstones=*/false);
+        auto summary = builder::build_from_samples(grove, samples);
         ASSERT_EQ(summary.counters.absorbed_segments, 1u);
         default_edge_count = grove.edge_count();
     }
@@ -329,11 +313,7 @@ TEST_F(BuilderPipelineTest, BuildSummary_WrittenFileContainsCounters) {
     samples.back().type = "sample";
 
     grove_type grove(3);
-    auto summary = builder::build_from_samples(
-        grove, samples,
-        /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*fuzzy_tolerance=*/5,
-        /*prune_tombstones=*/false);
+    auto summary = builder::build_from_samples(grove, samples);
 
     fs::path summary_path = tmp_dir / "test.ggx.summary";
     summary.write_summary(summary_path.string());
@@ -389,11 +369,10 @@ TEST_F(BuilderPipelineTest, ReverseAbsorption_QtxRemap) {
 
     std::string qtx_path = (tmp_dir / "test.qtx").string();
     grove_type grove(3);
-    auto summary = builder::build_from_samples(
-        grove, samples,
-        /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*fuzzy_tolerance=*/5, /*prune_tombstones=*/false,
-        /*include_scaffolds=*/true, qtx_path);
+    build_options qtx_opts;
+    qtx_opts.include_scaffolds = true;
+    qtx_opts.qtx_path = qtx_path;
+    auto summary = builder::build_from_samples(grove, samples, qtx_opts);
 
     ASSERT_EQ(summary.counters.absorbed_segments, 1u)
         << "rep1's 3-exon segment should be reverse-absorbed into rep2's 4-exon parent";
@@ -480,11 +459,10 @@ TEST_F(BuilderPipelineTest, TransitiveChain_QtxRemap) {
 
     std::string qtx_path = (tmp_dir / "chain.qtx").string();
     grove_type grove(3);
-    auto summary = builder::build_from_samples(
-        grove, samples,
-        /*threads=*/1, /*filters=*/expression_filters{}, /*absorb=*/true,
-        /*fuzzy_tolerance=*/5, /*prune_tombstones=*/false,
-        /*include_scaffolds=*/true, qtx_path);
+    build_options qtx_opts;
+    qtx_opts.include_scaffolds = true;
+    qtx_opts.qtx_path = qtx_path;
+    auto summary = builder::build_from_samples(grove, samples, qtx_opts);
 
     EXPECT_GE(summary.counters.absorbed_segments, 2u)
         << "Both A and B should be absorbed (A→B→C chain)";

--- a/tests/build/hub_psi_entropy_test.cpp
+++ b/tests/build/hub_psi_entropy_test.cpp
@@ -145,9 +145,12 @@ TEST_F(HubPsiEntropyTest, PsiAndEntropyCorrectForKnownHub) {
     size_t segment_count = 0;
     build_counters counters;
 
+    build_options test_opts;
+    test_opts.absorb = false;
+    test_opts.include_scaffolds = true;
+
     build_gff::build(grove, gtf_path, sample_id, exon_caches, segment_caches,
-                     segment_count, 0, expression_filters{}, false, 5,
-                     /*include_scaffolds=*/true, counters);
+                     segment_count, test_opts, counters);
 
     // Verify we got the expected number of segments: 12 hub-using + 1 non-hub = 13
     ASSERT_EQ(segment_count, 13u) << "Expected 13 segments (12 through hub + 1 bypass)";

--- a/tests/build/serialization_test.cpp
+++ b/tests/build/serialization_test.cpp
@@ -54,9 +54,12 @@ protected:
         [[maybe_unused]] auto anno_id = sample_registry::instance().register_data(anno_info);
 
         build_counters counters;
+        build_options test_opts;
+        test_opts.absorb = false;
+        test_opts.include_scaffolds = true;
+
         build_gff::build(*grove_, anno_path, 0, exon_caches_, segment_caches_,
-                         segment_count_, 0, expression_filters{}, false, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count_, test_opts, counters);
 
         // Register sample (with expression)
         sample_info samp_info("TEST_SAMPLE");
@@ -64,8 +67,7 @@ protected:
         [[maybe_unused]] auto samp_id = sample_registry::instance().register_data(samp_info);
 
         build_gff::build(*grove_, sample_path, 1, exon_caches_, segment_caches_,
-                         segment_count_, 0, expression_filters{}, false, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count_, test_opts, counters);
     }
 
     // Serialize grove + registries to temp file (mirrors subcall::save_grove)

--- a/tests/discover/sqanti_category_test.cpp
+++ b/tests/discover/sqanti_category_test.cpp
@@ -52,9 +52,12 @@ protected:
 
         // absorb=false to keep all segments as separate candidates
         build_counters counters;
+        build_options test_opts;
+        test_opts.absorb = false;
+        test_opts.include_scaffolds = true;
+
         build_gff::build(*grove, fixture, sample_id, exon_caches, segment_caches,
-                         segment_count, 0, expression_filters{}, false, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count, test_opts, counters);
 
         ASSERT_GT(segment_count, 0) << "No segments built from fixture";
     }
@@ -382,9 +385,12 @@ protected:
         uint32_t sample_id = sample_registry::instance().register_data(info);
 
         build_counters counters;
+        build_options test_opts;
+        test_opts.absorb = false;
+        test_opts.include_scaffolds = true;
+
         build_gff::build(*grove, gtf, sample_id, exon_caches, segment_caches,
-                         segment_count, 0, expression_filters{}, false, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_count, test_opts, counters);
     }
 
     std::unique_ptr<grove_type> grove;

--- a/tests/query/query_classification_test.cpp
+++ b/tests/query/query_classification_test.cpp
@@ -66,10 +66,12 @@ protected:
         annotation_id = sample_registry::instance().register_data(anno_info);
 
         build_counters counters;
+        build_options test_opts;
+        test_opts.absorb = false;
+        test_opts.include_scaffolds = true;
+
         build_gff::build(*grove, anno_path, annotation_id, exon_caches,
-                         segment_caches, segment_count,
-                         0, expression_filters{}, false, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_caches, segment_count, test_opts, counters);
 
         // Register and build sample
         sample_info sample_info_obj("TEST_SAMPLE");
@@ -77,9 +79,7 @@ protected:
         sample_id = sample_registry::instance().register_data(sample_info_obj);
 
         build_gff::build(*grove, sample_path, sample_id, exon_caches,
-                         segment_caches, segment_count,
-                         0, expression_filters{}, false, 5,
-                         /*include_scaffolds=*/true, counters);
+                         segment_caches, segment_count, test_opts, counters);
 
         ASSERT_GT(segment_count, 0);
     }


### PR DESCRIPTION
## Summary
Replaces 13-15 individual parameters with a single `build_options` struct across the build pipeline. Closes [#57](https://github.com/ylab-hi/atroplex/issues/57). Net -63 lines.

**Affected signatures:**
- `builder::build_from_samples()` — 13 params → 4 (grove, samples, opts, out_exon_caches)
- `build_gff::build()` — 13 params → 9 (grove, filepath, sample_id, caches×2, segment_count, opts, counters, sidecar)
- `build_bam::build()` — same reduction
- `build_gff::process_gene()` / `process_transcript()` — same reduction

`build_options` struct lives in `build_summary.hpp` (alongside `build_counters` and `expression_filters`).

## QC
- [x] I, as a human being, have checked each line of code in this pull request
- [x] All tests pass
- [x] build_from_samples callers use build_options struct
- [x] No bare parameter references remain in builder/build_gff/build_bam