### PR TITLE
Decouple query::run_dtu from cxxopts + document read_cluster lifetime (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **`query::run_dtu` no longer takes `cxxopts::ParseResult`** ([#88](https://github.com/ylab-hi/atroplex/pull/88), partial [#13](https://github.com/ylab-hi/atroplex/issues/13)): the parameter was already unused (commented out as `/*args*/` in the impl); removed from the signature and the single caller in `query::execute`. Matches the audit's "business logic shouldn't depend on CLI parsing types" recommendation. Also documents the `read_cluster::members` lifetime constraint (non-owning pointers into `read_clusterer::read_storage_` invalidated by `finalize_chromosome()`) — previously safe but undocumented.
+
 ### Removed
 - **Dead/stub files** ([#87](https://github.com/ylab-hi/atroplex/pull/87), partial [#13](https://github.com/ylab-hi/atroplex/issues/13)): five header/source pairs the audit flagged as never-used or stub. Removed `include/alignment.hpp` + `src/alignment.cpp` (empty constructor stub), `include/segment_identifier.hpp` (empty class skeleton), `include/data.hpp` (placeholder `exon` / `segment` / `transcript` structs superseded by `genomic_feature.hpp`'s variant-based feature system), `include/graph_structure.hpp` (old experimental layout), and `include/index_stats.hpp` + `src/index_stats.cpp` (2233 LOC) — replaced by `analysis_report` since PR #27 and no longer wired into any subcommand or test target. Two stale `// Future extension methods` comments in `builder.hpp` referencing types that don't exist (`alignment_entry`, `fusion_data`) also dropped. Net diff: −2634 lines. `CMakeLists.txt` uses `file(GLOB)` so no build-config change was needed.
 

--- a/include/read_cluster.hpp
+++ b/include/read_cluster.hpp
@@ -116,7 +116,14 @@ struct read_cluster {
     size_t start;                              // Min start across all members
     size_t end;                                // Max end across all members
     std::vector<splice_junction> consensus_junctions;
-    std::vector<const processed_read*> members; // Non-owning pointers
+    /// Non-owning pointers into the owning `read_clusterer::read_storage_`
+    /// vector. These pointers are valid only until
+    /// `read_clusterer::finalize_chromosome()` runs, which empties
+    /// `read_storage_` and frees the underlying `processed_read` objects.
+    /// Consumers must finish using a returned `read_cluster` before the
+    /// next chromosome's reads are added; storing the cluster across
+    /// `finalize_chromosome()` calls leaves these pointers dangling.
+    std::vector<const processed_read*> members;
 
     read_cluster() : strand('.'), start(SIZE_MAX), end(0) {}
 

--- a/include/subcall/query.hpp
+++ b/include/subcall/query.hpp
@@ -129,8 +129,7 @@ private:
      */
     std::vector<dtu_result> run_dtu(
         const query_contrast& contrast,
-        const std::vector<query_result>& results,
-        const cxxopts::ParseResult& args);
+        const std::vector<query_result>& results);
 
     /**
      * Benjamini–Hochberg FDR correction. Mutates `results.fdr` and

--- a/src/subcall/query.cpp
+++ b/src/subcall/query.cpp
@@ -169,7 +169,7 @@ void query::execute(const cxxopts::ParseResult& args) {
             auto contrast = query_contrast::parse(spec);
             logging::info("Running DTU: " + contrast.group_a + " vs " + contrast.group_b);
 
-            auto dtu = run_dtu(contrast, results, args);
+            auto dtu = run_dtu(contrast, results);
             apply_fdr_correction(dtu, fdr_threshold);
 
             size_t sig = std::count_if(dtu.begin(), dtu.end(),
@@ -404,8 +404,7 @@ void query::write_classification(const std::string& path,
 
 std::vector<dtu_result> query::run_dtu(
     const query_contrast& contrast,
-    const std::vector<query_result>& results,
-    const cxxopts::ParseResult& /*args*/) {
+    const std::vector<query_result>& results) {
 
     auto& registry = sample_registry::instance();
 


### PR DESCRIPTION
Partial: closes items 5 and 6 in #13. Remaining: feature-type duplication between `exon_feature` / `segment_feature` (item 1; bigger refactor that needs a design pass).

## Summary

Two small audit follow-ups, both behavior-preserving:

### 1. `query::run_dtu` no longer takes `cxxopts::ParseResult`
The parameter was already unused (commented out in the impl as `/*args*/`). Removed from both the declaration in `subcall/query.hpp` and the single caller in `query::execute`. Matches the audit's "business logic shouldn't depend on CLI parsing types" recommendation.

`run_dtu` now takes only `(contrast, results)`.

### 2. Documented `read_cluster::members` lifetime constraint
`read_cluster::members` is a `vector<const processed_read*>` whose pointers are non-owning references into the owning `read_clusterer::read_storage_`. `read_clusterer::finalize_chromosome()` empties that storage at line `read_cluster.cpp:222`, invalidating every pointer in every cluster returned for the prior chromosome.

The audit flagged this as "currently safe but undocumented." Added a doc-comment explaining the constraint so consumers understand it without having to read the clusterer implementation. Includes the specific function name and the failure mode ("storing the cluster across `finalize_chromosome()` calls leaves these pointers dangling").

## QC
- [ ] I, as a human being, have checked each line of code in this pull request
- [x] All existing test suites pass — the parameter removal is a pure signature simplification (the impl was already ignoring `args`); the doc change is comment-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)